### PR TITLE
게시글 생성, 수정, 삭제 API 구현

### DIFF
--- a/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
+++ b/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
@@ -1,0 +1,12 @@
+package com.service.dida.domain.nft.repository;
+
+import com.service.dida.domain.nft.Nft;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NftRepository extends JpaRepository<Nft, Long> {
+
+    Optional<Nft> findByNftId(Long nftId);
+}

--- a/src/main/java/com/service/dida/domain/post/Post.java
+++ b/src/main/java/com/service/dida/domain/post/Post.java
@@ -44,4 +44,9 @@ public class Post extends BaseEntity {
 
     @OneToMany(mappedBy = "post", cascade = {CascadeType.ALL}, orphanRemoval = true)
     private List<Comment> comments;
+
+    public void editPost(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/service/dida/domain/post/Post.java
+++ b/src/main/java/com/service/dida/domain/post/Post.java
@@ -49,4 +49,7 @@ public class Post extends BaseEntity {
         this.title = title;
         this.content = content;
     }
+    public void setDeleted() {
+        this.deleted = true;
+    }
 }

--- a/src/main/java/com/service/dida/domain/post/controller/PostController.java
+++ b/src/main/java/com/service/dida/domain/post/controller/PostController.java
@@ -9,10 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,9 +30,19 @@ public class PostController {
      *  [PATCH] /post
      */
     @PatchMapping("/post")
-    public ResponseEntity<Integer> editPost(@RequestBody @Valid EditPostReq editPostReq) {
+    public ResponseEntity<Integer> editPost(@RequestBody @Valid EditPostReq editPostReq) throws BaseException {
         Long userId = 0L;
         postService.editPost(userId, editPostReq);
+        return new ResponseEntity<Integer>(200, HttpStatus.OK);
+    }
+
+    /** 게시글 수정하기
+     *  [PATCH] /post/delete
+     */
+    @PatchMapping("/post/delete")
+    public ResponseEntity<Integer> deletePost(@PathVariable("postId") Long postId) throws BaseException {
+        Long userId = 0L;
+        postService.deletePost(userId, postId);
         return new ResponseEntity<Integer>(200, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/service/dida/domain/post/controller/PostController.java
+++ b/src/main/java/com/service/dida/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.post.controller;
 
 
+import com.service.dida.domain.post.dto.EditPostReq;
 import com.service.dida.domain.post.dto.PostPostReq;
 import com.service.dida.domain.post.service.PostService;
 import com.service.dida.global.config.exception.BaseException;
@@ -8,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +26,16 @@ public class PostController {
     public ResponseEntity<Integer> createPost(@RequestBody @Valid PostPostReq postPostReq) throws BaseException {
         Long userId = 0L;
         postService.createPost(userId, postPostReq);
+        return new ResponseEntity<Integer>(200, HttpStatus.OK);
+    }
+
+    /** 게시글 수정하기
+     *  [PATCH] /post
+     */
+    @PatchMapping("/post")
+    public ResponseEntity<Integer> editPost(@RequestBody @Valid EditPostReq editPostReq) {
+        Long userId = 0L;
+        postService.editPost(userId, editPostReq);
         return new ResponseEntity<Integer>(200, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/service/dida/domain/post/controller/PostController.java
+++ b/src/main/java/com/service/dida/domain/post/controller/PostController.java
@@ -1,4 +1,29 @@
 package com.service.dida.domain.post.controller;
 
+
+import com.service.dida.domain.post.dto.PostPostReq;
+import com.service.dida.domain.post.service.PostService;
+import com.service.dida.global.config.exception.BaseException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class PostController {
+    private final PostService postService;
+
+    /** 게시글 생성하기
+     *  [POST] /post
+     */
+    @PostMapping("/post")
+    public ResponseEntity<Integer> createPost(@RequestBody @Valid PostPostReq postPostReq) throws BaseException {
+        Long userId = 0L;
+        postService.createPost(userId, postPostReq);
+        return new ResponseEntity<Integer>(200, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/service/dida/domain/post/controller/PostController.java
+++ b/src/main/java/com/service/dida/domain/post/controller/PostController.java
@@ -1,0 +1,4 @@
+package com.service.dida.domain.post.controller;
+
+public class PostController {
+}

--- a/src/main/java/com/service/dida/domain/post/dto/EditPostReq.java
+++ b/src/main/java/com/service/dida/domain/post/dto/EditPostReq.java
@@ -1,0 +1,21 @@
+package com.service.dida.domain.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class EditPostReq {
+    @NotBlank(message = "수정하려는 게시글의 Id를 입력하세요.")
+    private Long postId;
+    @NotBlank(message = "제목을 입력하세요.")
+    @Size(min = 2, max = 30, message = "제목의 길이는 2~20이어야 합니다.")
+    private String title;
+    @NotBlank(message = "본문을 입력하세요.")
+    @Size(min = 2, max = 300, message = "본문의 길이는 2~300이어야 합니다.")
+    private String content;
+}

--- a/src/main/java/com/service/dida/domain/post/dto/PostPostReq.java
+++ b/src/main/java/com/service/dida/domain/post/dto/PostPostReq.java
@@ -1,0 +1,22 @@
+package com.service.dida.domain.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PostPostReq {
+    @NotBlank(message = "게시글을 작성하려는 nftId를 입력하세요.")
+    private Long nftId;
+    @NotBlank(message = "제목을 입력하세요.")
+    @Size(min = 2, max = 30, message = "제목의 길이는 2~20이어야 합니다.")
+    private String title;
+    @NotBlank(message = "본문을 입력하세요.")
+    @Size(min = 2, max = 300, message = "본문의 길이는 2~300이어야 합니다.")
+    private String content;
+}

--- a/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.service.dida.domain.post.repository;
+
+import com.service.dida.domain.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package com.service.dida.domain.post.repository;
 
 import com.service.dida.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 }

--- a/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
@@ -4,6 +4,9 @@ import com.service.dida.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByPostId(Long postId);
 }

--- a/src/main/java/com/service/dida/domain/post/service/PostService.java
+++ b/src/main/java/com/service/dida/domain/post/service/PostService.java
@@ -1,4 +1,50 @@
 package com.service.dida.domain.post.service;
 
+import com.service.dida.domain.nft.Nft;
+import com.service.dida.domain.nft.repository.NftRepository;
+import com.service.dida.domain.post.Post;
+import com.service.dida.domain.post.dto.PostPostReq;
+import com.service.dida.domain.post.repository.PostRepository;
+import com.service.dida.domain.user.User;
+import com.service.dida.domain.user.repository.UserRepository;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.NftErrorCode;
+import com.service.dida.global.config.exception.errorCode.UserErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class PostService {
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final NftRepository nftRepository;
+
+    @Transactional
+    public void save(Post post) {
+        postRepository.save(post);
+    }
+
+    @Transactional
+    public void createPost(Long userId, PostPostReq postPostReq) {
+        User user = userRepository.findByUserId(userId).orElse(null);
+        if(!user.isValidated()) {
+            throw new BaseException(UserErrorCode.EMPTY_USER);
+        }
+        Nft nft = nftRepository.findByNftId(postPostReq.getNftId()).orElse(null);
+        if(nft.isValidated()) {
+            throw new BaseException(NftErrorCode.EMPTY_NFT);
+        }
+
+        Post post = Post.builder()
+                .title(postPostReq.getTitle())
+                .content(postPostReq.getContent())
+                .user(user)
+                .nft(nft)
+                .build();
+
+        save(post);
+    }
+
 }

--- a/src/main/java/com/service/dida/domain/post/service/PostService.java
+++ b/src/main/java/com/service/dida/domain/post/service/PostService.java
@@ -1,0 +1,4 @@
+package com.service.dida.domain.post.service;
+
+public class PostService {
+}

--- a/src/main/java/com/service/dida/domain/post/service/PostService.java
+++ b/src/main/java/com/service/dida/domain/post/service/PostService.java
@@ -3,12 +3,14 @@ package com.service.dida.domain.post.service;
 import com.service.dida.domain.nft.Nft;
 import com.service.dida.domain.nft.repository.NftRepository;
 import com.service.dida.domain.post.Post;
+import com.service.dida.domain.post.dto.EditPostReq;
 import com.service.dida.domain.post.dto.PostPostReq;
 import com.service.dida.domain.post.repository.PostRepository;
 import com.service.dida.domain.user.User;
 import com.service.dida.domain.user.repository.UserRepository;
 import com.service.dida.global.config.exception.BaseException;
 import com.service.dida.global.config.exception.errorCode.NftErrorCode;
+import com.service.dida.global.config.exception.errorCode.PostErrorCode;
 import com.service.dida.global.config.exception.errorCode.UserErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +31,11 @@ public class PostService {
     @Transactional
     public void createPost(Long userId, PostPostReq postPostReq) {
         User user = userRepository.findByUserId(userId).orElse(null);
-        if(!user.isValidated()) {
+        if (!user.isValidated()) {
             throw new BaseException(UserErrorCode.EMPTY_USER);
         }
         Nft nft = nftRepository.findByNftId(postPostReq.getNftId()).orElse(null);
-        if(nft.isValidated()) {
+        if (!nft.isValidated()) {
             throw new BaseException(NftErrorCode.EMPTY_NFT);
         }
 
@@ -45,6 +47,25 @@ public class PostService {
                 .build();
 
         save(post);
+    }
+
+    public boolean checkIsMe(Long userId, Long ownerId) {
+        if (userId.equals(ownerId)) {
+            return true;
+        } else {
+            throw new BaseException(PostErrorCode.NOT_OWN_POST);
+        }
+    }
+
+    @Transactional
+    public void editPost(Long userId, EditPostReq editPostReq) {
+        Post post = postRepository.findByPostId(editPostReq.getPostId()).orElse(null);
+        if (post.isDeleted()) {
+            throw new BaseException(PostErrorCode.EMPTY_POST);
+        }
+        if(checkIsMe(userId, post.getUser().getUserId())) {
+            post.editPost(editPostReq.getTitle(), editPostReq.getContent());
+        }
     }
 
 }

--- a/src/main/java/com/service/dida/domain/post/service/PostService.java
+++ b/src/main/java/com/service/dida/domain/post/service/PostService.java
@@ -6,6 +6,7 @@ import com.service.dida.domain.post.Post;
 import com.service.dida.domain.post.dto.EditPostReq;
 import com.service.dida.domain.post.dto.PostPostReq;
 import com.service.dida.domain.post.repository.PostRepository;
+import com.service.dida.domain.post.usecase.PostUseCase;
 import com.service.dida.domain.user.User;
 import com.service.dida.domain.user.repository.UserRepository;
 import com.service.dida.global.config.exception.BaseException;
@@ -18,16 +19,17 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class PostService {
+public class PostService implements PostUseCase {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final NftRepository nftRepository;
-
+    @Override
     @Transactional
     public void save(Post post) {
         postRepository.save(post);
     }
 
+    @Override
     @Transactional
     public void createPost(Long userId, PostPostReq postPostReq) {
         User user = userRepository.findByUserId(userId).orElse(null);
@@ -49,6 +51,10 @@ public class PostService {
         save(post);
     }
 
+    /**
+     * 나의 게시글인지 체크하는 함수
+     */
+    @Override
     public boolean checkIsMe(Long userId, Long ownerId) {
         if (userId.equals(ownerId)) {
             return true;
@@ -56,7 +62,7 @@ public class PostService {
             throw new BaseException(PostErrorCode.NOT_OWN_POST);
         }
     }
-
+    @Override
     @Transactional
     public void editPost(Long userId, EditPostReq editPostReq) {
         Post post = postRepository.findByPostId(editPostReq.getPostId()).orElse(null);
@@ -68,6 +74,7 @@ public class PostService {
         }
     }
 
+    @Override
     @Transactional
     public void deletePost(Long userId, Long postId) {
         Post post = postRepository.findByPostId(postId).orElse(null);

--- a/src/main/java/com/service/dida/domain/post/service/PostService.java
+++ b/src/main/java/com/service/dida/domain/post/service/PostService.java
@@ -31,11 +31,11 @@ public class PostService {
     @Transactional
     public void createPost(Long userId, PostPostReq postPostReq) {
         User user = userRepository.findByUserId(userId).orElse(null);
-        if (!user.isValidated()) {
+        if (user == null || user.isDeleted()) {
             throw new BaseException(UserErrorCode.EMPTY_USER);
         }
         Nft nft = nftRepository.findByNftId(postPostReq.getNftId()).orElse(null);
-        if (!nft.isValidated()) {
+        if (nft == null || nft.isDeleted()) {
             throw new BaseException(NftErrorCode.EMPTY_NFT);
         }
 
@@ -60,11 +60,22 @@ public class PostService {
     @Transactional
     public void editPost(Long userId, EditPostReq editPostReq) {
         Post post = postRepository.findByPostId(editPostReq.getPostId()).orElse(null);
-        if (post.isDeleted()) {
+        if (post == null || post.isDeleted()) {
             throw new BaseException(PostErrorCode.EMPTY_POST);
         }
-        if(checkIsMe(userId, post.getUser().getUserId())) {
+        if (checkIsMe(userId, post.getUser().getUserId())) {
             post.editPost(editPostReq.getTitle(), editPostReq.getContent());
+        }
+    }
+
+    @Transactional
+    public void deletePost(Long userId, Long postId) {
+        Post post = postRepository.findByPostId(postId).orElse(null);
+        if (post == null || post.isDeleted()) {
+            throw new BaseException(PostErrorCode.EMPTY_POST);
+        }
+        if (checkIsMe(userId, post.getUser().getUserId())) {
+            post.setDeleted();
         }
     }
 

--- a/src/main/java/com/service/dida/domain/post/usecase/GetPostUseCase.java
+++ b/src/main/java/com/service/dida/domain/post/usecase/GetPostUseCase.java
@@ -1,4 +1,0 @@
-package com.service.dida.domain.post.usecase;
-
-public interface GetPostUseCase {
-}

--- a/src/main/java/com/service/dida/domain/post/usecase/GetPostUseCase.java
+++ b/src/main/java/com/service/dida/domain/post/usecase/GetPostUseCase.java
@@ -1,0 +1,4 @@
+package com.service.dida.domain.post.usecase;
+
+public interface GetPostUseCase {
+}

--- a/src/main/java/com/service/dida/domain/post/usecase/PostUseCase.java
+++ b/src/main/java/com/service/dida/domain/post/usecase/PostUseCase.java
@@ -1,0 +1,13 @@
+package com.service.dida.domain.post.usecase;
+
+import com.service.dida.domain.post.Post;
+import com.service.dida.domain.post.dto.EditPostReq;
+import com.service.dida.domain.post.dto.PostPostReq;
+
+public interface PostUseCase {
+    void save(Post post);
+    void createPost(Long userId, PostPostReq postPostReq);
+    boolean checkIsMe(Long userId, Long ownerId);
+    void editPost(Long userId, EditPostReq editPostReq);
+    void deletePost(Long userId, Long postId);
+}

--- a/src/main/java/com/service/dida/global/config/exception/errorCode/NftErrorCode.java
+++ b/src/main/java/com/service/dida/global/config/exception/errorCode/NftErrorCode.java
@@ -1,0 +1,14 @@
+package com.service.dida.global.config.exception.errorCode;
+
+import com.service.dida.global.config.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NftErrorCode implements ErrorCode {
+    EMPTY_NFT("NFT_001", "유효하지 않는 NFT입니다.")
+    ;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/service/dida/global/config/exception/errorCode/PostErrorCode.java
+++ b/src/main/java/com/service/dida/global/config/exception/errorCode/PostErrorCode.java
@@ -1,0 +1,15 @@
+package com.service.dida.global.config.exception.errorCode;
+
+import com.service.dida.global.config.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PostErrorCode implements ErrorCode {
+    EMPTY_POST("POST_001", "유효하지 않은 게시글입니다."),
+    NOT_OWN_POST("POST_002", "자신의 게시글이 아닙니다.")
+    ;
+    private final String errorCode;
+    private final String message;
+}


### PR DESCRIPTION
### 요약
게시글 생성, 수정, 삭제 API를 구현했습니다.
- 
### 상세 내용

- 기존 API보다 깔끔하게 URI 정리
- DTO에서 어노테이션을 이용한 validation 처리
- 도메인 별로 controller, service, repository, dto, usecase 분리
### 질문 및 이외 사항

- PostUseCase를 추가해보았습니다! 그런데 저번에 보여주신 예시에서, GetPostUseCase, UpdatePostUseCase 이런 식으로 같은 PostUseCase라도 여러개로 분리하셨던 것 같은데, 이렇게 분리를 할 경우 Service도 같이 분리 해야하는 것으로 알고 있습니다. 준영님께서 어떻게 작업하실지 알려주시면 저도 통일하도록 하겠습니다!
- 그리고 User Entity 안에 `isValidated()` 라는 validation 확인 메서드를 만들었었는데, User Entity의 기본 getter 함수인 `isDeleted()`을 사용하는 것과 차이가 없다고 생각하여 `isDeleted()`로 개발하였습니다! 여기에 관해 의견 주시면 `isValidated()`를 삭제하거나 수정하겠습니다! 
### 이슈 번호

- close #48, #49, #50