### PR TITLE
NFT 좋아요 & NFT 숨김 기능 구현

### DIFF
--- a/src/main/java/com/service/dida/domain/comment/controller/RegisterCommentController.java
+++ b/src/main/java/com/service/dida/domain/comment/controller/RegisterCommentController.java
@@ -21,9 +21,9 @@ public class RegisterCommentController {
 
     /**
      * 댓글 생성하기
-     * [POST] /comment
+     * [POST] /common/comment
      */
-    @PostMapping("comment")
+    @PostMapping("/common/comment")
     public ResponseEntity<Integer> registerComment(
             @CurrentMember Member member,
             @RequestBody @Valid PostCommentRequestDto postCommentRequestDto)

--- a/src/main/java/com/service/dida/domain/comment/controller/UpdateCommentController.java
+++ b/src/main/java/com/service/dida/domain/comment/controller/UpdateCommentController.java
@@ -19,9 +19,9 @@ public class UpdateCommentController {
 
     /**
      * 댓글 삭제하기
-     * [PATCH] /comment/delete
+     * [PATCH] /common/comment/delete
      */
-    @PatchMapping("/comment/delete")
+    @PatchMapping("/common/comment/delete")
     public ResponseEntity<Integer> deleteComment(
             @CurrentMember Member member,
             @RequestParam("commentId") Long commentId)

--- a/src/main/java/com/service/dida/domain/comment/service/GetCommentService.java
+++ b/src/main/java/com/service/dida/domain/comment/service/GetCommentService.java
@@ -41,6 +41,7 @@ public class GetCommentService implements GetCommentUseCase {
     /**
      * 나의 댓글인지를 나타내는 type 을 반환하는 함수
      */
+    @Override
     public String checkIsMe(Member member, Member owner) {
         String type;
         if (member == null) {  // 로그인하지 않았다면

--- a/src/main/java/com/service/dida/domain/comment/service/RegisterCommentService.java
+++ b/src/main/java/com/service/dida/domain/comment/service/RegisterCommentService.java
@@ -27,9 +27,6 @@ public class RegisterCommentService implements RegisterCommentUseCase {
     @Override
     @Transactional
     public void registerComment(Member member, PostCommentRequestDto postCommentRequestDto) {
-        if (member == null) {
-            throw new BaseException(MemberErrorCode.EMPTY_MEMBER);
-        }
         Post post = postRepository.findByPostIdWithDeleted(postCommentRequestDto.getPostId()).orElse(null);
 
         Comment comment = Comment.builder()

--- a/src/main/java/com/service/dida/domain/comment/service/UpdateCommentService.java
+++ b/src/main/java/com/service/dida/domain/comment/service/UpdateCommentService.java
@@ -10,6 +10,7 @@ import com.service.dida.global.config.exception.errorCode.CommentErrorCode;
 import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,12 +21,11 @@ public class UpdateCommentService implements UpdateCommentUseCase {
 
     /**
      * 나의 댓글인지 체크하는 함수
+     *
      */
+    @PreAuthorize("hasAnyRole('VISITOR, MEMBER')")
     public boolean checkIsMe(Member member, Member owner) {
-        if (member == null) {
-            throw new BaseException(MemberErrorCode.EMPTY_MEMBER);
-        }
-        else if(member.equals(owner)) {
+        if(member.equals(owner)) {
             return true;
         } else {
             throw new BaseException(CommentErrorCode.NOT_OWN_COMMENT);

--- a/src/main/java/com/service/dida/domain/comment/service/UpdateCommentService.java
+++ b/src/main/java/com/service/dida/domain/comment/service/UpdateCommentService.java
@@ -16,17 +16,16 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UpdateCommentService implements UpdateCommentUseCase {
 
-    private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
 
     /**
      * 나의 댓글인지 체크하는 함수
      */
-    public boolean checkIsMe(Member member, Long ownerId) {
+    public boolean checkIsMe(Member member, Member owner) {
         if (member == null) {
             throw new BaseException(MemberErrorCode.EMPTY_MEMBER);
         }
-        else if(member.getMemberId().equals(ownerId)) {
+        else if(member.equals(owner)) {
             return true;
         } else {
             throw new BaseException(CommentErrorCode.NOT_OWN_COMMENT);
@@ -39,7 +38,7 @@ public class UpdateCommentService implements UpdateCommentUseCase {
         Comment comment = commentRepository.findByCommentIdWithDeleted(commentId)
                 .orElseThrow(() -> new BaseException(CommentErrorCode.EMPTY_COMMENT));
 
-        if (checkIsMe(member, comment.getMember().getMemberId())) {
+        if (checkIsMe(member, comment.getMember())) {
             comment.setDeleted();
         }
     }

--- a/src/main/java/com/service/dida/domain/comment/usecase/GetCommentUseCase.java
+++ b/src/main/java/com/service/dida/domain/comment/usecase/GetCommentUseCase.java
@@ -14,4 +14,6 @@ public interface GetCommentUseCase {
     PageResponseDto<List<CommentResponseDto.GetCommentResponseDto>> makeCommentListForm(Member member, Page<Comment> comments);
     List<CommentResponseDto.GetCommentResponseDto> getPreviewComments(Long postId);
     PageResponseDto<List<CommentResponseDto.GetCommentResponseDto>> getAllComments(Member member, Long postId, PageRequestDto pageRequestDto);
+    String checkIsMe(Member member, Member owner);
+
 }

--- a/src/main/java/com/service/dida/domain/hide/Hide.java
+++ b/src/main/java/com/service/dida/domain/hide/Hide.java
@@ -1,0 +1,36 @@
+package com.service.dida.domain.hide;
+
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@NoArgsConstructor
+@Table(name = "nft_hide")
+public class Hide {
+    @Id
+    @Column(name = "hide_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long hideId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "nft_id")
+    private Nft nft;
+
+    @Column(name = "status", nullable = false, columnDefinition = "boolean default true")
+    private boolean status;
+
+    public boolean changeStatus() {
+        this.status = !this.status;
+        return this.status;
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/Hide.java
+++ b/src/main/java/com/service/dida/domain/hide/Hide.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Builder
 @Getter
 @AllArgsConstructor
-@RequiredArgsConstructor
 @NoArgsConstructor
 @Table(name = "nft_hide")
 public class Hide {

--- a/src/main/java/com/service/dida/domain/hide/controller/GetHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/controller/GetHideController.java
@@ -1,0 +1,34 @@
+package com.service.dida.domain.hide.controller;
+
+import com.service.dida.domain.hide.dto.HideResponseDto.GetHideNft;
+import com.service.dida.domain.hide.usecase.GetHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class GetHideController {
+    private final GetHideUseCase getHideUseCase;
+
+    /**
+     * NFT 숨김 목록 조회
+     * [GET] /nft/hide
+     */
+    @GetMapping("nft/hide")
+    public ResponseEntity<PageResponseDto<List<GetHideNft>>> getHideNftList(
+            @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
+            throws BaseException {
+        return new ResponseEntity<>(getHideUseCase.getHideNftList(member, pageRequestDto), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/controller/GetHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/controller/GetHideController.java
@@ -23,9 +23,9 @@ public class GetHideController {
 
     /**
      * NFT 숨김 목록 조회
-     * [GET] /nft/hide
+     * [GET] /common/nft/hide
      */
-    @GetMapping("nft/hide")
+    @GetMapping("/common/nft/hide")
     public ResponseEntity<PageResponseDto<List<GetHideNft>>> getHideNftList(
             @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
             throws BaseException {

--- a/src/main/java/com/service/dida/domain/hide/controller/RegisterHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/controller/RegisterHideController.java
@@ -1,0 +1,30 @@
+package com.service.dida.domain.hide.controller;
+
+import com.service.dida.domain.hide.usecase.RegisterHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RegisterHideController {
+    private final RegisterHideUseCase registerHideUseCase;
+
+    /**
+     * NFT 숨기기
+     * [POST] /nft/hide
+     */
+    @PostMapping("/nft/hide")
+    public ResponseEntity<Integer> hideCard(
+            @RequestParam("nftId") Long nftId, @CurrentMember Member member)
+            throws BaseException {
+        registerHideUseCase.hideCard(member, nftId);
+        return new ResponseEntity<>(200, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/controller/RegisterHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/controller/RegisterHideController.java
@@ -18,9 +18,9 @@ public class RegisterHideController {
 
     /**
      * NFT 숨기기
-     * [POST] /nft/hide
+     * [POST] /common/nft/hide
      */
-    @PostMapping("/nft/hide")
+    @PostMapping("/common/nft/hide")
     public ResponseEntity<Integer> hideCard(
             @RequestParam("nftId") Long nftId, @CurrentMember Member member)
             throws BaseException {

--- a/src/main/java/com/service/dida/domain/hide/controller/UpdateHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/controller/UpdateHideController.java
@@ -17,9 +17,9 @@ public class UpdateHideController {
 
     /**
      * NFT 숨기기 취소
-     * [DELETE] /nft/hide
+     * [DELETE] /common/nft/hide
      */
-    @DeleteMapping("/nft/hide")
+    @DeleteMapping("/common/nft/hide")
     public ResponseEntity<Integer> unhideNft(
             @RequestParam("nftId") Long nftId, @CurrentMember Member member)
             throws BaseException {

--- a/src/main/java/com/service/dida/domain/hide/controller/UpdateHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/controller/UpdateHideController.java
@@ -1,0 +1,29 @@
+package com.service.dida.domain.hide.controller;
+
+import com.service.dida.domain.hide.usecase.UpdateHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class UpdateHideController {
+
+    private final UpdateHideUseCase updateHideUseCase;
+
+    /**
+     * NFT 숨기기 취소
+     * [DELETE] /nft/hide
+     */
+    @DeleteMapping("/nft/hide")
+    public ResponseEntity<Integer> unhideNft(
+            @RequestParam("nftId") Long nftId, @CurrentMember Member member)
+            throws BaseException {
+            updateHideUseCase.unhideNft(member, nftId);
+        return new ResponseEntity<>(200, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/dto/HideResponseDto.java
+++ b/src/main/java/com/service/dida/domain/hide/dto/HideResponseDto.java
@@ -1,0 +1,19 @@
+package com.service.dida.domain.hide.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+public class HideResponseDto {
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class GetHideNft {
+        private Long nftId;
+        private String nftName;
+        private String nftImgUrl;
+        private String memberName;
+        private String price;
+    }
+
+}

--- a/src/main/java/com/service/dida/domain/hide/repository/HideRepository.java
+++ b/src/main/java/com/service/dida/domain/hide/repository/HideRepository.java
@@ -3,11 +3,14 @@ package com.service.dida.domain.hide.repository;
 import com.service.dida.domain.hide.Hide;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface HideRepository extends JpaRepository<Hide, Long> {
-
     Optional<Hide> findByMemberAndNft(Member member, Nft nft);
+
+    Page<Hide> findByMember(Member member, PageRequest pageRequest);
 }

--- a/src/main/java/com/service/dida/domain/hide/repository/HideRepository.java
+++ b/src/main/java/com/service/dida/domain/hide/repository/HideRepository.java
@@ -1,0 +1,13 @@
+package com.service.dida.domain.hide.repository;
+
+import com.service.dida.domain.hide.Hide;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface HideRepository extends JpaRepository<Hide, Long> {
+
+    Optional<Hide> findByMemberAndNft(Member member, Nft nft);
+}

--- a/src/main/java/com/service/dida/domain/hide/service/GetHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/service/GetHideService.java
@@ -59,4 +59,12 @@ public class GetHideService implements GetHideUseCase {
         return new PageResponseDto<>(
                 hides.getNumber(), hides.getSize(), hides.hasNext(), res);
     }
+
+    /**
+     * 숨긴 NFT 인지 확인하는 함수, 숨긴 NFT 라면 true 리턴
+     * Member, Nft 검증 기능 포함 X
+     */
+    public boolean checkIsHided(Member member, Nft nft) {
+        return hideRepository.findByMemberAndNft(member, nft).isPresent();
+    }
 }

--- a/src/main/java/com/service/dida/domain/hide/service/GetHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/service/GetHideService.java
@@ -1,0 +1,62 @@
+package com.service.dida.domain.hide.service;
+
+import com.service.dida.domain.hide.Hide;
+import com.service.dida.domain.hide.dto.HideResponseDto.GetHideNft;
+import com.service.dida.domain.hide.repository.HideRepository;
+import com.service.dida.domain.hide.usecase.GetHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetHideService implements GetHideUseCase {
+
+    private final HideRepository hideRepository;
+
+    /**
+     * NFT 숨김 목록 조회에서 공통으로 사용 될 PageRequest 를 정의하는 함수
+     */
+    public PageRequest pageReq(PageRequestDto pageRequestDto) {
+        // pageRequest 는 원하는 page, 한 page 당 size, 최신 순서 정렬 이라는 요청을 담고 있다.
+        return PageRequest.of(pageRequestDto.getPage(), pageRequestDto.getPageSize()
+                , Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+    public GetHideNft makeGetHideNftForm(Nft nft) {
+        return GetHideNft.builder()
+                .nftId(nft.getNftId())
+                .nftName(nft.getTitle())
+                .nftImgUrl(nft.getImgUrl())
+                .memberName(nft.getMember().getNickname())
+                .price(nft.getPrice())
+                .build();
+    }
+
+    @Override
+    public PageResponseDto<List<GetHideNft>> getHideNftList(Member member, PageRequestDto pageRequestDto) {
+        if(member == null) {
+            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
+        }
+        Page<Hide> hides = hideRepository.findByMember(member, pageReq(pageRequestDto));
+
+        List<GetHideNft> res = new ArrayList<>();
+
+        for(Hide h : hides.getContent()) {
+            res.add(makeGetHideNftForm(h.getNft()));
+        }
+        return new PageResponseDto<>(
+                hides.getNumber(), hides.getSize(), hides.hasNext(), res);
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/service/GetHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/service/GetHideService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -46,9 +47,6 @@ public class GetHideService implements GetHideUseCase {
 
     @Override
     public PageResponseDto<List<GetHideNft>> getHideNftList(Member member, PageRequestDto pageRequestDto) {
-        if(member == null) {
-            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
-        }
         Page<Hide> hides = hideRepository.findByMember(member, pageReq(pageRequestDto));
 
         List<GetHideNft> res = new ArrayList<>();
@@ -62,8 +60,10 @@ public class GetHideService implements GetHideUseCase {
 
     /**
      * 숨긴 NFT 인지 확인하는 함수, 숨긴 NFT 라면 true 리턴
-     * Member, Nft 검증 기능 포함 X
+     * Nft 검증 기능 포함 X
      */
+    @Override
+    @PreAuthorize("hasAnyRole('VISITOR, MEMBER')")
     public boolean checkIsHided(Member member, Nft nft) {
         return hideRepository.findByMemberAndNft(member, nft).isPresent();
     }

--- a/src/main/java/com/service/dida/domain/hide/service/RegisterHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/service/RegisterHideService.java
@@ -35,9 +35,6 @@ public class RegisterHideService implements RegisterHideUseCase {
     @Override
     @Transactional
     public void hideCard(Member member, Long nftId) {
-        if (member == null) {
-            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
-        }
         Nft nft = nftRepository.findByNftIdWithDeleted(nftId)
                 .orElseThrow(() -> new BaseException(NftErrorCode.EMPTY_NFT));
         Hide hide = hideRepository.findByMemberAndNft(member, nft).orElse(null);

--- a/src/main/java/com/service/dida/domain/hide/service/RegisterHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/service/RegisterHideService.java
@@ -1,0 +1,51 @@
+package com.service.dida.domain.hide.service;
+
+import com.service.dida.domain.hide.Hide;
+import com.service.dida.domain.hide.repository.HideRepository;
+import com.service.dida.domain.hide.usecase.RegisterHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
+import com.service.dida.domain.nft.repository.NftRepository;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.HideErrorCode;
+import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
+import com.service.dida.global.config.exception.errorCode.NftErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterHideService implements RegisterHideUseCase {
+    private final HideRepository hideRepository;
+    private final NftRepository nftRepository;
+
+    @Transactional
+    public void save(Hide hide) {
+        hideRepository.save(hide);
+    }
+
+    public void createHide(Member member, Nft nft) {
+        save(Hide.builder()
+                .member(member)
+                .nft(nft)
+                .build());
+    }
+
+    @Override
+    @Transactional
+    public void hideCard(Member member, Long nftId) {
+        if (member == null) {
+            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
+        }
+        Nft nft = nftRepository.findByNftIdWithDeleted(nftId)
+                .orElseThrow(() -> new BaseException(NftErrorCode.EMPTY_NFT));
+        Hide hide = hideRepository.findByMemberAndNft(member, nft).orElse(null);
+        if (hide == null) {
+            createHide(member, nft);
+        } else {
+            throw new BaseException(HideErrorCode.ALREADY_HIDE);
+        }
+    }
+
+}

--- a/src/main/java/com/service/dida/domain/hide/service/UpdateHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/service/UpdateHideService.java
@@ -24,9 +24,6 @@ public class UpdateHideService implements UpdateHideUseCase {
     @Override
     @Transactional
     public void unhideNft(Member member, Long nftId) {
-        if(member == null) {
-            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
-        }
         Nft nft = nftRepository.findByNftIdWithDeleted(nftId)
                 .orElseThrow(() -> new BaseException(NftErrorCode.EMPTY_NFT));
         Hide hide = hideRepository.findByMemberAndNft(member, nft).orElse(null);

--- a/src/main/java/com/service/dida/domain/hide/service/UpdateHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/service/UpdateHideService.java
@@ -1,0 +1,39 @@
+package com.service.dida.domain.hide.service;
+
+import com.service.dida.domain.hide.Hide;
+import com.service.dida.domain.hide.repository.HideRepository;
+import com.service.dida.domain.hide.usecase.UpdateHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
+import com.service.dida.domain.nft.repository.NftRepository;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.HideErrorCode;
+import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
+import com.service.dida.global.config.exception.errorCode.NftErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateHideService implements UpdateHideUseCase {
+
+    private final HideRepository hideRepository;
+    private final NftRepository nftRepository;
+
+    @Override
+    @Transactional
+    public void unhideNft(Member member, Long nftId) {
+        if(member == null) {
+            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
+        }
+        Nft nft = nftRepository.findByNftIdWithDeleted(nftId)
+                .orElseThrow(() -> new BaseException(NftErrorCode.EMPTY_NFT));
+        Hide hide = hideRepository.findByMemberAndNft(member, nft).orElse(null);
+        if(hide == null) { //비어있다면 숨기지 않은 카드이므로 예외 처리
+            throw new BaseException(HideErrorCode.NOT_HIDE);
+        } else {
+            hideRepository.delete(hide);
+        }
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/usecase/GetHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/usecase/GetHideUseCase.java
@@ -11,4 +11,5 @@ import java.util.List;
 public interface GetHideUseCase {
     public PageResponseDto<List<HideResponseDto.GetHideNft>> getHideNftList(Member member, PageRequestDto pageRequestDto);
     boolean checkIsHided(Member member, Nft nft);
+
 }

--- a/src/main/java/com/service/dida/domain/hide/usecase/GetHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/usecase/GetHideUseCase.java
@@ -2,6 +2,7 @@ package com.service.dida.domain.hide.usecase;
 
 import com.service.dida.domain.hide.dto.HideResponseDto;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
 import com.service.dida.global.common.dto.PageRequestDto;
 import com.service.dida.global.common.dto.PageResponseDto;
 
@@ -9,4 +10,5 @@ import java.util.List;
 
 public interface GetHideUseCase {
     public PageResponseDto<List<HideResponseDto.GetHideNft>> getHideNftList(Member member, PageRequestDto pageRequestDto);
+    boolean checkIsHided(Member member, Nft nft);
 }

--- a/src/main/java/com/service/dida/domain/hide/usecase/GetHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/usecase/GetHideUseCase.java
@@ -1,0 +1,12 @@
+package com.service.dida.domain.hide.usecase;
+
+import com.service.dida.domain.hide.dto.HideResponseDto;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+
+import java.util.List;
+
+public interface GetHideUseCase {
+    public PageResponseDto<List<HideResponseDto.GetHideNft>> getHideNftList(Member member, PageRequestDto pageRequestDto);
+}

--- a/src/main/java/com/service/dida/domain/hide/usecase/RegisterHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/usecase/RegisterHideUseCase.java
@@ -1,0 +1,7 @@
+package com.service.dida.domain.hide.usecase;
+
+import com.service.dida.domain.member.entity.Member;
+
+public interface RegisterHideUseCase {
+    void hideCard(Member member, Long nftId);
+}

--- a/src/main/java/com/service/dida/domain/hide/usecase/UpdateHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/usecase/UpdateHideUseCase.java
@@ -1,0 +1,7 @@
+package com.service.dida.domain.hide.usecase;
+
+import com.service.dida.domain.member.entity.Member;
+
+public interface UpdateHideUseCase {
+    void unhideNft(Member member, Long nftId);
+}

--- a/src/main/java/com/service/dida/domain/like/Like.java
+++ b/src/main/java/com/service/dida/domain/like/Like.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Builder
 @Getter
 @AllArgsConstructor
-@RequiredArgsConstructor
 @NoArgsConstructor
 @Table(name = "nft_like")
 public class Like {

--- a/src/main/java/com/service/dida/domain/like/Like.java
+++ b/src/main/java/com/service/dida/domain/like/Like.java
@@ -3,15 +3,13 @@ package com.service.dida.domain.like;
 import com.service.dida.domain.nft.Nft;
 import com.service.dida.domain.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Builder
 @Getter
 @AllArgsConstructor
+@RequiredArgsConstructor
 @NoArgsConstructor
 @Table(name = "nft_like")
 public class Like {
@@ -30,4 +28,9 @@ public class Like {
 
     @Column(name = "status", nullable = false, columnDefinition = "boolean default true")
     private boolean status;
+
+    public boolean changeStatus() {
+        this.status = !this.status;
+        return this.status;
+    }
 }

--- a/src/main/java/com/service/dida/domain/like/controller/RegisterLikeController.java
+++ b/src/main/java/com/service/dida/domain/like/controller/RegisterLikeController.java
@@ -20,9 +20,9 @@ public class RegisterLikeController {
 
     /**
      * 좋아요 누르기
-     * [POST] /nft/like
+     * [POST] /common/nft/like
      */
-    @PostMapping("/nft/like")
+    @PostMapping("/common/nft/like")
     public ResponseEntity<Boolean> pushLike(
             @RequestParam("nftId") Long nftId, @CurrentMember Member member)
             throws BaseException {

--- a/src/main/java/com/service/dida/domain/like/controller/RegisterLikeController.java
+++ b/src/main/java/com/service/dida/domain/like/controller/RegisterLikeController.java
@@ -1,0 +1,32 @@
+package com.service.dida.domain.like.controller;
+
+import com.service.dida.domain.like.usecase.RegisterLikeUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RegisterLikeController {
+
+    private final RegisterLikeUseCase registerLikeUseCase;
+
+    /**
+     * 좋아요 누르기
+     * [POST] /nft/like
+     */
+    @PostMapping("/nft/like")
+    public ResponseEntity<Boolean> pushLike(
+            @RequestParam("nftId") Long nftId, @CurrentMember Member member)
+            throws BaseException {
+        return new ResponseEntity<>(registerLikeUseCase.pushLike(member, nftId), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/service/dida/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/service/dida/domain/like/repository/LikeRepository.java
@@ -1,9 +1,11 @@
-package com.service.dida.domain.like;
+package com.service.dida.domain.like.repository;
 
 import java.awt.print.Pageable;
 import java.util.List;
 import java.util.Optional;
 
+import com.service.dida.domain.like.Like;
+import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +17,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     @Query(value = "SELECT COUNT(l) FROM Like l WHERE l.nft = :nft AND l.status = true")
     Optional<Long> getLikeCountsByNftId(Nft nft);
+
+    Optional<Like> findByMemberAndNft(Member member, Nft nft);
 }

--- a/src/main/java/com/service/dida/domain/like/service/GetLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/GetLikeService.java
@@ -6,6 +6,7 @@ import com.service.dida.domain.like.usecase.GetLikeUseCase;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,8 +17,10 @@ public class GetLikeService implements GetLikeUseCase {
 
     /**
      * 좋아요를 누른 상태라면 true 를, 누르지 않은 상태라면 false 리턴
-     * Member, Nft 검증 기능 포함 X
+     * Nft 검증 기능 포함 X
      */
+    @Override
+    @PreAuthorize("hasAnyRole('VISITOR, MEMBER')")
     public boolean checkIsLiked(Member member, Nft nft) {
         Like like = likeRepository.findByMemberAndNft(member, nft).orElse(null);
         if (like == null) {

--- a/src/main/java/com/service/dida/domain/like/service/GetLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/GetLikeService.java
@@ -1,0 +1,29 @@
+package com.service.dida.domain.like.service;
+
+import com.service.dida.domain.like.Like;
+import com.service.dida.domain.like.repository.LikeRepository;
+import com.service.dida.domain.like.usecase.GetLikeUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetLikeService implements GetLikeUseCase {
+
+    private final LikeRepository likeRepository;
+
+    /**
+     * 좋아요를 누른 상태라면 true 를, 누르지 않은 상태라면 false 리턴
+     * Member, Nft 검증 기능 포함 X
+     */
+    public boolean checkIsLiked(Member member, Nft nft) {
+        Like like = likeRepository.findByMemberAndNft(member, nft).orElse(null);
+        if (like == null) {
+            return false;
+        } else {
+            return like.isStatus();
+        }
+    }
+}

--- a/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
@@ -35,9 +35,6 @@ public class RegisterLikeService implements RegisterLikeUseCase {
     @Override
     @Transactional
     public boolean pushLike(Member member, Long nftId) {
-        if (member == null) {
-            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
-        }
         Nft nft = nftRepository.findByNftIdWithDeleted(nftId)
                 .orElseThrow(() -> new BaseException(NftErrorCode.EMPTY_NFT));
 

--- a/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
@@ -50,17 +50,4 @@ public class RegisterLikeService implements RegisterLikeUseCase {
         }
     }
 
-    /**
-     * 좋아요를 누른 상태라면 true 를, 누르지 않은 상태라면 false 리턴
-     * Member, Nft 검증 기능 포함 X
-     */
-    public boolean checkIsLiked(Member member, Nft nft) {
-        Like like = likeRepository.findByMemberAndNft(member, nft).orElse(null);
-        if (like == null) {
-            return false;
-        } else {
-            return like.isStatus();
-        }
-    }
-
 }

--- a/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
@@ -50,4 +50,17 @@ public class RegisterLikeService implements RegisterLikeUseCase {
         }
     }
 
+    // 좋아요를 누른 상태라면 true 를, 누르지 않은 상태라면 false 리턴
+    public boolean checkIsLiked(Member member, Nft nft) {
+        if (member == null) {
+            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
+        }
+        Like like = likeRepository.findByMemberAndNft(member, nft).orElse(null);
+        if (like == null) {
+            return false;
+        } else {
+            return like.isStatus();
+        }
+    }
+
 }

--- a/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
@@ -50,11 +50,11 @@ public class RegisterLikeService implements RegisterLikeUseCase {
         }
     }
 
-    // 좋아요를 누른 상태라면 true 를, 누르지 않은 상태라면 false 리턴
+    /**
+     * 좋아요를 누른 상태라면 true 를, 누르지 않은 상태라면 false 리턴
+     * Member, Nft 검증 기능 포함 X
+     */
     public boolean checkIsLiked(Member member, Nft nft) {
-        if (member == null) {
-            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
-        }
         Like like = likeRepository.findByMemberAndNft(member, nft).orElse(null);
         if (like == null) {
             return false;

--- a/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
@@ -1,0 +1,53 @@
+package com.service.dida.domain.like.service;
+
+
+import com.service.dida.domain.like.Like;
+import com.service.dida.domain.like.repository.LikeRepository;
+import com.service.dida.domain.like.usecase.RegisterLikeUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
+import com.service.dida.domain.nft.repository.NftRepository;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
+import com.service.dida.global.config.exception.errorCode.NftErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterLikeService implements RegisterLikeUseCase {
+    private final LikeRepository likeRepository;
+    private final NftRepository nftRepository;
+
+    @Transactional
+    public void save(Like like) {
+        likeRepository.save(like);
+    }
+
+    public void createLike(Member member, Nft nft) {
+        save(Like.builder()
+                .member(member)
+                .nft(nft)
+                .build());
+    }
+
+    @Override
+    @Transactional
+    public boolean pushLike(Member member, Long nftId) {
+        if (member == null) {
+            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
+        }
+        Nft nft = nftRepository.findByNftIdWithDeleted(nftId)
+                .orElseThrow(() -> new BaseException(NftErrorCode.EMPTY_NFT));
+
+        Like like = likeRepository.findByMemberAndNft(member, nft).orElse(null);
+        if (like == null) {
+            createLike(member, nft);
+            return true;
+        } else {
+            return like.changeStatus();
+        }
+    }
+
+}

--- a/src/main/java/com/service/dida/domain/like/usecase/GetLikeUseCase.java
+++ b/src/main/java/com/service/dida/domain/like/usecase/GetLikeUseCase.java
@@ -1,0 +1,8 @@
+package com.service.dida.domain.like.usecase;
+
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
+
+public interface GetLikeUseCase {
+    boolean checkIsLiked(Member member, Nft nft);
+}

--- a/src/main/java/com/service/dida/domain/like/usecase/RegisterLikeUseCase.java
+++ b/src/main/java/com/service/dida/domain/like/usecase/RegisterLikeUseCase.java
@@ -1,0 +1,7 @@
+package com.service.dida.domain.like.usecase;
+
+import com.service.dida.domain.member.entity.Member;
+
+public interface RegisterLikeUseCase {
+    boolean pushLike(Member member, Long nftId);
+}

--- a/src/main/java/com/service/dida/domain/market/MarketService.java
+++ b/src/main/java/com/service/dida/domain/market/MarketService.java
@@ -3,7 +3,7 @@ package com.service.dida.domain.market;
 import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
 
 import com.service.dida.global.config.exception.BaseException;
-import com.service.dida.domain.like.LikeRepository;
+import com.service.dida.domain.like.repository.LikeRepository;
 import com.service.dida.domain.market.dto.*;
 import com.service.dida.domain.nft.Nft;
 import com.service.dida.domain.member.entity.Member;

--- a/src/main/java/com/service/dida/domain/nft/Nft.java
+++ b/src/main/java/com/service/dida/domain/nft/Nft.java
@@ -64,4 +64,13 @@ public class Nft extends BaseEntity {
     public void changeDeleted(boolean flag) {
         this.deleted = flag;
     }
+
+    public String getPrice() {
+        String price = "NOT SALE";
+        if (this.isMarketed()) {
+            price = String.format("%.6f", Double.valueOf(
+                    this.getMarkets().get(this.getMarkets().size() - 1).getPrice() * 1000000).longValue() / 1000000f);
+        }
+        return price;
+    }
 }

--- a/src/main/java/com/service/dida/domain/post/controller/RegisterPostController.java
+++ b/src/main/java/com/service/dida/domain/post/controller/RegisterPostController.java
@@ -19,9 +19,9 @@ public class RegisterPostController {
 
     /**
      * 게시글 생성하기
-     * [POST] /post
+     * [POST] /common/post
      */
-    @PostMapping("/post")
+    @PostMapping("/common/post")
     public ResponseEntity<Integer> createPost(
             @RequestBody @Valid PostPostRequestDto postPostRequestDto,
             @CurrentMember Member member)

--- a/src/main/java/com/service/dida/domain/post/controller/UpdatePostController.java
+++ b/src/main/java/com/service/dida/domain/post/controller/UpdatePostController.java
@@ -19,9 +19,9 @@ public class UpdatePostController {
 
     /**
      * 게시글 수정하기
-     * [PATCH] /post
+     * [PATCH] /common/post
      */
-    @PatchMapping("/post")
+    @PatchMapping("/common/post")
     public ResponseEntity<Integer> editPost(
             @RequestBody @Valid EditPostRequestDto editPostRequestDto,
             @CurrentMember Member member)
@@ -32,9 +32,9 @@ public class UpdatePostController {
 
     /**
      * 게시글 삭제하기
-     * [PATCH] /post/delete
+     * [PATCH] /common/post/delete
      */
-    @PatchMapping("/post/delete")
+    @PatchMapping("/common/post/delete")
     public ResponseEntity<Integer> deletePost(
             @RequestParam("postId") Long postId, @CurrentMember Member member)
             throws BaseException {

--- a/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.post.repository;
 
+import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.post.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,6 +17,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query(value = "select p from Post p where p.postId = :postId and p.deleted = false")
     Optional<Post> findByPostIdWithDeleted(Long postId);
     Optional<Post> findByPostId(Long postId);
+
+    /**
+    @Query(value = "SELECT p FROM Post p, (SELECT h FROM Hide h WHERE h.member = :member AND p.nft = h.nft) " +
+            "WHERE p.deleted = false AND h.nft != p.nft")
+    Page<Post> findAllWithDeleted(Member member, PageRequest pageRequest);
+     */
 
     @Query(value = "SELECT p FROM Post p WHERE p.deleted = false")
     Page<Post> findAllWithDeleted(PageRequest pageRequest);

--- a/src/main/java/com/service/dida/domain/post/service/GetPostService.java
+++ b/src/main/java/com/service/dida/domain/post/service/GetPostService.java
@@ -59,17 +59,6 @@ public class GetPostService implements GetPostUseCase {
     }
 
     /**
-     * 마켓에 등록되었다면 price 를 반환하는 함수
-     */
-    public String getPrice(Nft nft) {
-        String price = "NOT SALE";
-        if (nft.isMarketed()) {
-            price = utilService.doubleToString(nft.getMarkets().get(nft.getMarkets().size() - 1).getPrice());
-        }
-        return price;
-    }
-
-    /**
      * 1개의 Post 를 GetPostResponseDto 형태로 만들어주는 함수
      * GetPostResponseDto 는 PostInfo, MemberInfo, NftInfo, comments, type 을 가진다.
      */
@@ -83,7 +72,7 @@ public class GetPostService implements GetPostUseCase {
 
         NftResponseDto.NftInfo nftInfo = new NftResponseDto.NftInfo(
                 post.getNft().getNftId(), post.getNft().getTitle(), post.getNft().getImgUrl(),
-                getPrice(post.getNft()));
+                post.getNft().getPrice());
 
         List<CommentResponseDto.GetCommentResponseDto> comments = new ArrayList<>();
         if (needComment) {

--- a/src/main/java/com/service/dida/domain/post/service/RegisterPostService.java
+++ b/src/main/java/com/service/dida/domain/post/service/RegisterPostService.java
@@ -30,9 +30,6 @@ public class RegisterPostService implements RegisterPostUseCase {
     @Override
     @Transactional
     public void createPost(Member member, PostPostRequestDto postPostRequestDto) {
-        if (member == null) {
-            throw new BaseException(MemberErrorCode.EMPTY_MEMBER);
-        }
         Nft nft = nftRepository.findByNftIdWithDeleted(postPostRequestDto.getNftId())
                 .orElseThrow(() -> new BaseException(NftErrorCode.EMPTY_NFT));
         Post post = Post.builder()

--- a/src/main/java/com/service/dida/domain/post/service/UpdatePostService.java
+++ b/src/main/java/com/service/dida/domain/post/service/UpdatePostService.java
@@ -11,6 +11,7 @@ import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
 import com.service.dida.global.config.exception.errorCode.PostErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,10 +25,9 @@ public class UpdatePostService implements UpdatePostUseCase {
     /**
      * 나의 게시글인지 체크하는 함수
      */
+    @PreAuthorize("hasAnyRole('VISITOR, MEMBER')")
     public boolean checkIsMe(Member member, Member owner) {
-        if (member == null) {
-            throw new BaseException(MemberErrorCode.EMPTY_MEMBER);
-        } else if (member.equals(owner)) {
+        if (member.equals(owner)) {
             return true;
         } else {
             throw new BaseException(PostErrorCode.NOT_OWN_POST);

--- a/src/main/java/com/service/dida/domain/post/usecase/GetPostUseCase.java
+++ b/src/main/java/com/service/dida/domain/post/usecase/GetPostUseCase.java
@@ -15,4 +15,5 @@ public interface GetPostUseCase {
     PageResponseDto<List<PostResponseDto.GetPostResponseDto>> getAllPosts(Member member, PageRequestDto pageRequestDto);
     PageResponseDto<List<PostResponseDto.GetPostResponseDto>> getPostsByNftId(Member member, Long nftId, PageRequestDto pageRequestDto);
     PostResponseDto.GetPostResponseDto getPost(Member member, Long postId);
+    String checkIsMe(Member member, Member owner);
 }

--- a/src/main/java/com/service/dida/global/config/exception/errorCode/HideErrorCode.java
+++ b/src/main/java/com/service/dida/global/config/exception/errorCode/HideErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum HideErrorCode implements ErrorCode {
     ALREADY_HIDE("HIDE_001", "이미 숨긴 NFT입니다.", HttpStatus.CONFLICT),
     SELF_HIDE("HIDE_002", "자신의 NFT는 숨길 수 없습니다.", HttpStatus.CONFLICT),
+    NOT_HIDE("HIDE_003", "숨기지 않은 NFT입니다.", HttpStatus.CONFLICT)
     ;
 
     private final String errorCode;

--- a/src/main/java/com/service/dida/global/config/exception/errorCode/HideErrorCode.java
+++ b/src/main/java/com/service/dida/global/config/exception/errorCode/HideErrorCode.java
@@ -1,0 +1,18 @@
+package com.service.dida.global.config.exception.errorCode;
+
+import com.service.dida.global.config.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum HideErrorCode implements ErrorCode {
+    ALREADY_HIDE("HIDE_001", "이미 숨긴 NFT입니다.", HttpStatus.CONFLICT),
+    SELF_HIDE("HIDE_002", "자신의 NFT는 숨길 수 없습니다.", HttpStatus.CONFLICT),
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+}


### PR DESCRIPTION
### 요약

- NFT 좋아요 API 구현
- NFT 숨기기 API 구현
- NFT 숨기기 취소 API 구현
- NFT 숨김 목록 조회 API 구현 (페이징 처리)
- 게시글 목록 조회에서 숨김 처리한 NFT는 보이지 않도록 처리 완료
### 상세 내용

- `GetHideUseCase`에 숨김 처리한 nft인지 확인하는 메서드
- `GetLikeUseCase`에 좋아요한 nft인지 확인하는 메서드
-  위 두 메서드 추가했으니 NFT 목록 조회 기능 개발하실 때 사용하시면 될 듯합니다!!
### 질문 및 이외 사항

- NFT 좋아요 API 커밋 메세지를 실수로 게시글 좋아요 API 구현 이라고 작성했네요 더 신경쓰겠습니다😅
- nft_hide의 경우 숨김 취소 했을 때 DB에 남겨둘 이유가 없을 것 같아서 hard delete로 처리했고, nft_like의 경우 상태 변경이 여러번 일어날 수 있다고 생각돼서 기존 그대로 soft delete 처리했습니다!!
- 게시글 목록을 조회 할 때, 페이징 요청을 통해 게시글 20개를 받아와도 nft 숨김 처리 한 걸 건너뛰면 19개..18개.. 이렇게 줄어들 텐데 이걸 해결할 방법 없을까요?! 계속 생각 중인데 생각이 잘 안나서 여쭤봅니다.,.😓 좋은 생각나면 바로 고치겠습니다!!!
### 이슈 번호

- close #68, close #62, close #63, close #64 