### PR TITLE
사용자 프로필 및 팔로우 확인 Api 개발

### DIFF
--- a/src/main/java/com/service/dida/domain/follow/Follow.java
+++ b/src/main/java/com/service/dida/domain/follow/Follow.java
@@ -1,10 +1,16 @@
 package com.service.dida.domain.follow;
 
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,17 +23,20 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "follow")
-public class Follow {
+public class Follow extends BaseEntity {
     @Id
     @Column(name = "follow_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long followId;
 
-    @Column(name = "following_id", nullable = false)
-    private Long followingId;   // 팔로우를 하는 사람
 
-    @Column(name = "follower_id", nullable = false)
-    private Long followerId;    // 팔로우를 당한 사람
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_member")
+    private Member followingMember; //팔로우를 하는 사람
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_member")
+    private Member followerMember; //팔로우를 당한 사람
 
     @Column(name = "status", nullable = false, columnDefinition = "boolean default true")
     private boolean status;

--- a/src/main/java/com/service/dida/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/service/dida/domain/follow/controller/FollowController.java
@@ -1,14 +1,20 @@
 package com.service.dida.domain.follow.controller;
 
+import com.service.dida.domain.follow.dto.FollowResponseDto.FollowList;
 import com.service.dida.domain.follow.usecase.GetFollowUseCase;
 import com.service.dida.domain.follow.usecase.RegisterFollowUseCase;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
 import com.service.dida.global.config.security.auth.CurrentMember;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,10 +27,21 @@ public class FollowController {
     /**
      * 팔로우 누르기 Api
      */
-    @PatchMapping("/member/follow/{memberId}")
+    @PatchMapping("/common/follow/{memberId}")
     public ResponseEntity<Integer> pushFollow(@CurrentMember Member member,
         @PathVariable(name = "memberId") Long memberId) {
         registerFollowUseCase.registerFollow(member, memberId);
         return new ResponseEntity<>(200, HttpStatus.OK);
+    }
+
+    /**
+     * 내 팔로우 목록 보기
+     */
+    @GetMapping("/common/follow")
+    public ResponseEntity<PageResponseDto<List<FollowList>>> getFollowerList(
+        @CurrentMember Member member,
+        @RequestBody PageRequestDto pageRequestDto) {
+        return new ResponseEntity<>(getFollowUseCase.getFollowerList(member, pageRequestDto),
+            HttpStatus.OK);
     }
 }

--- a/src/main/java/com/service/dida/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/service/dida/domain/follow/controller/FollowController.java
@@ -1,0 +1,30 @@
+package com.service.dida.domain.follow.controller;
+
+import com.service.dida.domain.follow.usecase.GetFollowUseCase;
+import com.service.dida.domain.follow.usecase.RegisterFollowUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final GetFollowUseCase getFollowUseCase;
+    private final RegisterFollowUseCase registerFollowUseCase;
+
+    /**
+     * 팔로우 누르기 Api
+     */
+    @PatchMapping("/member/follow/{memberId}")
+    public ResponseEntity<Integer> pushFollow(@CurrentMember Member member,
+        @PathVariable(name = "memberId") Long memberId) {
+        registerFollowUseCase.registerFollow(member, memberId);
+        return new ResponseEntity<>(200, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/service/dida/domain/follow/controller/FollowController.java
@@ -44,4 +44,15 @@ public class FollowController {
         return new ResponseEntity<>(getFollowUseCase.getFollowerList(member, pageRequestDto),
             HttpStatus.OK);
     }
+
+    /**
+     * 내 팔로잉 목록 보기
+     */
+    @GetMapping("/common/following")
+    public ResponseEntity<PageResponseDto<List<FollowList>>> getFollowingList(
+        @CurrentMember Member member,
+        @RequestBody PageRequestDto pageRequestDto) {
+        return new ResponseEntity<>(getFollowUseCase.getFollowingList(member, pageRequestDto),
+            HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/service/dida/domain/follow/dto/FollowResponseDto.java
+++ b/src/main/java/com/service/dida/domain/follow/dto/FollowResponseDto.java
@@ -1,0 +1,16 @@
+package com.service.dida.domain.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class FollowResponseDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class FollowList {
+        private Long memberId;
+        private String nickname;
+        private String profileUrl;
+        private int nftCnt;
+    }
+}

--- a/src/main/java/com/service/dida/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/service/dida/domain/follow/repository/FollowRepository.java
@@ -22,4 +22,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     @Query(value = "SELECT f FROM Follow f WHERE f.followerMember = :member AND f.status = TRUE")
     Page<Follow> findAllFollowerByMember(Member member, PageRequest pageRequest);
+
+    @Query(value = "SELECT f FROM Follow f WHERE f.followingMember = :member AND f.status = TRUE")
+    Page<Follow> findAllFollowingByMember(Member member, PageRequest pageRequest);
 }

--- a/src/main/java/com/service/dida/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/service/dida/domain/follow/repository/FollowRepository.java
@@ -11,4 +11,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     // NFT 소유자(혹은 보고 프로필의 주인)과 본인과의 팔로우 관계 가져오기
     @Query(value = "SELECT f FROM Follow f WHERE f.followingId = :memberId and f.followerId = :ownerId")
     Optional<Follow> findByMemberWithOwner(Long memberId, Long ownerId);
+
+    // 해당 멤버를 팔로우 하는 사람들의 수
+    Integer countByFollowerIdAndStatus(Long memberId, boolean status);
+
+    // 해당 멤버가 팔로잉 하는 사람들의 수
+    Integer countByFollowingIdAndStatus(Long memberId, boolean status);
 }

--- a/src/main/java/com/service/dida/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/service/dida/domain/follow/repository/FollowRepository.java
@@ -3,18 +3,23 @@ package com.service.dida.domain.follow.repository;
 import com.service.dida.domain.follow.Follow;
 import com.service.dida.domain.member.entity.Member;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     // NFT 소유자(혹은 보고 프로필의 주인)과 본인과의 팔로우 관계 가져오기
-    @Query(value = "SELECT f FROM Follow f WHERE f.followingId = :memberId and f.followerId = :ownerId")
-    Optional<Follow> findByMemberWithOwner(Long memberId, Long ownerId);
+    @Query(value = "SELECT f FROM Follow f WHERE f.followingMember = :member and f.followerMember = :owner")
+    Optional<Follow> findByMemberWithOwner(Member member, Member owner);
 
     // 해당 멤버를 팔로우 하는 사람들의 수
-    Integer countByFollowerIdAndStatus(Long memberId, boolean status);
+    Integer countByFollowerMemberAndStatus(Member member, boolean status);
 
     // 해당 멤버가 팔로잉 하는 사람들의 수
-    Integer countByFollowingIdAndStatus(Long memberId, boolean status);
+    Integer countByFollowingMemberAndStatus(Member member, boolean status);
+
+    @Query(value = "SELECT f FROM Follow f WHERE f.followerMember = :member AND f.status = TRUE")
+    Page<Follow> findAllFollowerByMember(Member member, PageRequest pageRequest);
 }

--- a/src/main/java/com/service/dida/domain/follow/service/GetFollowService.java
+++ b/src/main/java/com/service/dida/domain/follow/service/GetFollowService.java
@@ -1,10 +1,18 @@
 package com.service.dida.domain.follow.service;
 
 import com.service.dida.domain.follow.Follow;
+import com.service.dida.domain.follow.dto.FollowResponseDto.FollowList;
 import com.service.dida.domain.follow.repository.FollowRepository;
 import com.service.dida.domain.follow.usecase.GetFollowUseCase;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,14 +21,30 @@ public class GetFollowService implements GetFollowUseCase {
 
     private final FollowRepository followRepository;
 
+    public PageRequest pageReq(PageRequestDto pageRequestDto) {
+        // pageRequest 는 원하는 page, 한 page 당 size, 최신 순서 정렬 이라는 요청을 담고 있다.
+        return PageRequest.of(pageRequestDto.getPage(), pageRequestDto.getPageSize()
+            , Sort.by(Sort.Direction.DESC, "updatedAt"));
+    }
+
     @Override
     public boolean checkIsFollowed(Member member, Member owner) {
-        Follow follow = followRepository.findByMemberWithOwner(member.getMemberId(),
-            owner.getMemberId()).orElse(null);
+        Follow follow = followRepository.findByMemberWithOwner(member, owner).orElse(null);
         if (follow == null) {
             return false;
         } else {
             return follow.isStatus();
         }
+    }
+
+    @Override
+    public PageResponseDto<List<FollowList>> getFollowerList(Member member,
+        PageRequestDto pageRequestDto) {
+        List<FollowList> followLists = new ArrayList<>();
+        Page<Follow> follows = followRepository.findAllFollowerByMember(member,
+            pageReq(pageRequestDto));
+        follows.forEach(f -> followLists.add(f.getFollowingMember().setFollowList()));
+        return new PageResponseDto<>(follows.getNumber(), follows.getSize(), follows.hasNext(),
+            followLists);
     }
 }

--- a/src/main/java/com/service/dida/domain/follow/service/GetFollowService.java
+++ b/src/main/java/com/service/dida/domain/follow/service/GetFollowService.java
@@ -47,4 +47,15 @@ public class GetFollowService implements GetFollowUseCase {
         return new PageResponseDto<>(follows.getNumber(), follows.getSize(), follows.hasNext(),
             followLists);
     }
+
+    @Override
+    public PageResponseDto<List<FollowList>> getFollowingList(Member member,
+        PageRequestDto pageRequestDto) {
+        List<FollowList> followLists = new ArrayList<>();
+        Page<Follow> follows = followRepository.findAllFollowingByMember(member,
+            pageReq(pageRequestDto));
+        follows.forEach(f -> followLists.add(f.getFollowerMember().setFollowList()));
+        return new PageResponseDto<>(follows.getNumber(), follows.getSize(), follows.hasNext(),
+            followLists);
+    }
 }

--- a/src/main/java/com/service/dida/domain/follow/service/RegisterFollowService.java
+++ b/src/main/java/com/service/dida/domain/follow/service/RegisterFollowService.java
@@ -4,6 +4,7 @@ import com.service.dida.domain.follow.Follow;
 import com.service.dida.domain.follow.repository.FollowRepository;
 import com.service.dida.domain.follow.usecase.RegisterFollowUseCase;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.member.repository.MemberRepository;
 import com.service.dida.global.config.exception.BaseException;
 import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
 import jakarta.transaction.Transactional;
@@ -16,15 +17,16 @@ import org.springframework.stereotype.Service;
 public class RegisterFollowService implements RegisterFollowUseCase {
 
     private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
 
     public void save(Follow follow) {
         followRepository.save(follow);
     }
 
-    public void register(Long memberId,Long otherId) {
+    public void register(Member member, Member other) {
         Follow follow = Follow.builder()
-            .followerId(otherId)
-            .followingId(memberId)
+            .followerMember(other)
+            .followingMember(member)
             .status(true)
             .build();
         save(follow);
@@ -32,13 +34,14 @@ public class RegisterFollowService implements RegisterFollowUseCase {
 
     @Override
     public void registerFollow(Member member, Long otherId) {
-        if(member.getMemberId().equals(otherId)) {
+        if (member.getMemberId().equals(otherId)) {
             throw new BaseException(MemberErrorCode.INVALID_MEMBER);
         }
-        Follow follow = followRepository.findByMemberWithOwner(member.getMemberId(), otherId)
-            .orElse(null);
+        Member other = memberRepository.findByMemberIdWithDeleted(otherId)
+            .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
+        Follow follow = followRepository.findByMemberWithOwner(member, other).orElse(null);
         if (follow == null) {
-            register(member.getMemberId(), otherId);
+            register(member, other);
         } else {
             follow.changeStatus();
         }

--- a/src/main/java/com/service/dida/domain/follow/service/RegisterFollowService.java
+++ b/src/main/java/com/service/dida/domain/follow/service/RegisterFollowService.java
@@ -1,0 +1,46 @@
+package com.service.dida.domain.follow.service;
+
+import com.service.dida.domain.follow.Follow;
+import com.service.dida.domain.follow.repository.FollowRepository;
+import com.service.dida.domain.follow.usecase.RegisterFollowUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RegisterFollowService implements RegisterFollowUseCase {
+
+    private final FollowRepository followRepository;
+
+    public void save(Follow follow) {
+        followRepository.save(follow);
+    }
+
+    public void register(Long memberId,Long otherId) {
+        Follow follow = Follow.builder()
+            .followerId(otherId)
+            .followingId(memberId)
+            .status(true)
+            .build();
+        save(follow);
+    }
+
+    @Override
+    public void registerFollow(Member member, Long otherId) {
+        if(member.getMemberId().equals(otherId)) {
+            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
+        }
+        Follow follow = followRepository.findByMemberWithOwner(member.getMemberId(), otherId)
+            .orElse(null);
+        if (follow == null) {
+            register(member.getMemberId(), otherId);
+        } else {
+            follow.changeStatus();
+        }
+    }
+}

--- a/src/main/java/com/service/dida/domain/follow/usecase/GetFollowUseCase.java
+++ b/src/main/java/com/service/dida/domain/follow/usecase/GetFollowUseCase.java
@@ -11,4 +11,6 @@ public interface GetFollowUseCase {
     boolean checkIsFollowed(Member member, Member owner);
 
     PageResponseDto<List<FollowList>> getFollowerList(Member member, PageRequestDto pageRequestDto);
+
+    PageResponseDto<List<FollowList>> getFollowingList(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/follow/usecase/GetFollowUseCase.java
+++ b/src/main/java/com/service/dida/domain/follow/usecase/GetFollowUseCase.java
@@ -1,8 +1,14 @@
 package com.service.dida.domain.follow.usecase;
 
+import com.service.dida.domain.follow.dto.FollowResponseDto.FollowList;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import java.util.List;
 
 public interface GetFollowUseCase {
 
     boolean checkIsFollowed(Member member, Member owner);
+
+    PageResponseDto<List<FollowList>> getFollowerList(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/follow/usecase/RegisterFollowUseCase.java
+++ b/src/main/java/com/service/dida/domain/follow/usecase/RegisterFollowUseCase.java
@@ -1,0 +1,7 @@
+package com.service.dida.domain.follow.usecase;
+
+import com.service.dida.domain.member.entity.Member;
+
+public interface RegisterFollowUseCase {
+    void registerFollow(Member member,Long otherId);
+}

--- a/src/main/java/com/service/dida/domain/member/contorller/GetMemberController.java
+++ b/src/main/java/com/service/dida/domain/member/contorller/GetMemberController.java
@@ -47,7 +47,7 @@ public class GetMemberController {
     /**
      * 다른 유저 프로필 확인하기 Api
      */
-    @GetMapping("/common/profile/{memberId}")
+    @GetMapping("/profile/{memberId}")
     public ResponseEntity<OtherMemberDetailInfo> getOtherProfileDetailInfo(
         @CurrentMember Member member, @PathVariable(name = "memberId") Long memberId) {
         return new ResponseEntity<>(getUserUseCase.getOtherMemberDetailInfo(member, memberId),

--- a/src/main/java/com/service/dida/domain/member/contorller/GetMemberController.java
+++ b/src/main/java/com/service/dida/domain/member/contorller/GetMemberController.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.member.contorller;
 
+import com.service.dida.domain.member.dto.MemberResponseDto.MemberDetailInfo;
 import com.service.dida.domain.member.dto.MemberResponseDto.WalletExists;
 import com.service.dida.domain.member.dto.SendAuthEmailDto;
 import com.service.dida.domain.member.entity.Member;
@@ -25,8 +26,21 @@ public class GetMemberController {
         return new ResponseEntity<>(getUserUseCase.isExistWallet(member), HttpStatus.OK);
     }
 
+    /**
+     * 인증 메일 보내기 Api
+     */
     @GetMapping("/visitor/auth")
     public ResponseEntity<SendAuthEmailDto> sendAuthEmail(@CurrentMember Member member) {
         return new ResponseEntity<>(getUserUseCase.sendAuthMail(member), HttpStatus.OK);
     }
+
+    /**
+     * 내 프로필 확인하기 Api
+     */
+    @GetMapping("/common/profile")
+    public ResponseEntity<MemberDetailInfo> getDetailInfo(@CurrentMember Member member) {
+        return new ResponseEntity<>(getUserUseCase.getMemberDetailInfo(member),HttpStatus.OK);
+    }
+
+
 }

--- a/src/main/java/com/service/dida/domain/member/contorller/GetMemberController.java
+++ b/src/main/java/com/service/dida/domain/member/contorller/GetMemberController.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.member.contorller;
 
 import com.service.dida.domain.member.dto.MemberResponseDto.MemberDetailInfo;
+import com.service.dida.domain.member.dto.MemberResponseDto.OtherMemberDetailInfo;
 import com.service.dida.domain.member.dto.MemberResponseDto.WalletExists;
 import com.service.dida.domain.member.dto.SendAuthEmailDto;
 import com.service.dida.domain.member.entity.Member;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -38,9 +40,17 @@ public class GetMemberController {
      * 내 프로필 확인하기 Api
      */
     @GetMapping("/common/profile")
-    public ResponseEntity<MemberDetailInfo> getDetailInfo(@CurrentMember Member member) {
-        return new ResponseEntity<>(getUserUseCase.getMemberDetailInfo(member),HttpStatus.OK);
+    public ResponseEntity<MemberDetailInfo> getProfileDetailInfo(@CurrentMember Member member) {
+        return new ResponseEntity<>(getUserUseCase.getMemberDetailInfo(member), HttpStatus.OK);
     }
 
-
+    /**
+     * 다른 유저 프로필 확인하기 Api
+     */
+    @GetMapping("/common/profile/{memberId}")
+    public ResponseEntity<OtherMemberDetailInfo> getOtherProfileDetailInfo(
+        @CurrentMember Member member, @PathVariable(name = "memberId") Long memberId) {
+        return new ResponseEntity<>(getUserUseCase.getOtherMemberDetailInfo(member, memberId),
+            HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/service/dida/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/service/dida/domain/member/dto/MemberResponseDto.java
@@ -35,4 +35,14 @@ public class MemberResponseDto {
     public static class WalletExists {
         private boolean existed;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MemberDetailInfo{
+        private MemberInfo memberInfo;
+        private String description;
+        private int nftCnt;
+        private int followerCnt;
+        private int followingCnt;
+    }
 }

--- a/src/main/java/com/service/dida/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/service/dida/domain/member/dto/MemberResponseDto.java
@@ -38,11 +38,18 @@ public class MemberResponseDto {
 
     @Getter
     @AllArgsConstructor
-    public static class MemberDetailInfo{
+    public static class MemberDetailInfo {
         private MemberInfo memberInfo;
         private String description;
         private int nftCnt;
         private int followerCnt;
         private int followingCnt;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class OtherMemberDetailInfo {
+        private MemberDetailInfo memberDetailInfo;
+        private boolean followed;
     }
 }

--- a/src/main/java/com/service/dida/domain/member/entity/Member.java
+++ b/src/main/java/com/service/dida/domain/member/entity/Member.java
@@ -105,6 +105,7 @@ public class Member extends BaseEntity {
     }
 
     public FollowList setFollowList() {
-        return new FollowList(this.memberId,this.nickname,this.profileUrl,this.nfts.size());
+        int nftSize = (int) nfts.stream().filter(nft -> !nft.isDeleted()).count();
+        return new FollowList(this.memberId, this.nickname, this.profileUrl, nftSize);
     }
 }

--- a/src/main/java/com/service/dida/domain/member/entity/Member.java
+++ b/src/main/java/com/service/dida/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.member.entity;
 
+import com.service.dida.domain.follow.dto.FollowResponseDto.FollowList;
 import com.service.dida.domain.like.Like;
 import com.service.dida.domain.market.Market;
 import com.service.dida.domain.member.Role;
@@ -101,5 +102,9 @@ public class Member extends BaseEntity {
 
     public void plusReportCnt() {
         this.reportCnt++;
+    }
+
+    public FollowList setFollowList() {
+        return new FollowList(this.memberId,this.nickname,this.profileUrl,this.nfts.size());
     }
 }

--- a/src/main/java/com/service/dida/domain/member/service/GetMemberService.java
+++ b/src/main/java/com/service/dida/domain/member/service/GetMemberService.java
@@ -1,13 +1,18 @@
 package com.service.dida.domain.member.service;
 
 import com.service.dida.domain.follow.repository.FollowRepository;
+import com.service.dida.domain.follow.usecase.GetFollowUseCase;
 import com.service.dida.domain.member.dto.MemberResponseDto.MemberDetailInfo;
 import com.service.dida.domain.member.dto.MemberResponseDto.MemberInfo;
+import com.service.dida.domain.member.dto.MemberResponseDto.OtherMemberDetailInfo;
 import com.service.dida.domain.member.dto.MemberResponseDto.WalletExists;
 import com.service.dida.domain.member.dto.SendAuthEmailDto;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.member.repository.MemberRepository;
 import com.service.dida.domain.member.usecase.GetMemberUseCase;
 import com.service.dida.domain.nft.repository.NftRepository;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
 import com.service.dida.global.util.mail.MailUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +22,9 @@ import org.springframework.stereotype.Service;
 public class GetMemberService implements GetMemberUseCase {
 
     private final MailUseCase mailUseCase;
+    private final GetFollowUseCase getFollowUseCase;
     private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
     private final NftRepository nftRepository;
 
     @Override
@@ -41,5 +48,19 @@ public class GetMemberService implements GetMemberUseCase {
             member.getDescription(), nftRepository.countByMemberAndDeleted(member, false),
             followRepository.countByFollowerIdAndStatus(member.getMemberId(), true),
             followRepository.countByFollowingIdAndStatus(member.getMemberId(), true));
+    }
+
+    @Override
+    public OtherMemberDetailInfo getOtherMemberDetailInfo(Member member, Long memberId) {
+        Member other = memberRepository.findByMemberIdWithDeleted(memberId)
+            .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
+        return new OtherMemberDetailInfo(
+            new MemberDetailInfo(
+                new MemberInfo(other.getMemberId(), other.getNickname(), other.getProfileUrl()),
+                other.getDescription(), nftRepository.countByMemberAndDeleted(other, false),
+                followRepository.countByFollowerIdAndStatus(memberId, true),
+                followRepository.countByFollowingIdAndStatus(memberId, true)
+            ), getFollowUseCase.checkIsFollowed(member, other)
+        );
     }
 }

--- a/src/main/java/com/service/dida/domain/member/service/GetMemberService.java
+++ b/src/main/java/com/service/dida/domain/member/service/GetMemberService.java
@@ -46,8 +46,8 @@ public class GetMemberService implements GetMemberUseCase {
         return new MemberDetailInfo(
             new MemberInfo(member.getMemberId(), member.getNickname(), member.getProfileUrl()),
             member.getDescription(), nftRepository.countByMemberAndDeleted(member, false),
-            followRepository.countByFollowerIdAndStatus(member.getMemberId(), true),
-            followRepository.countByFollowingIdAndStatus(member.getMemberId(), true));
+            followRepository.countByFollowerMemberAndStatus(member, true),
+            followRepository.countByFollowingMemberAndStatus(member, true));
     }
 
     @Override
@@ -58,8 +58,8 @@ public class GetMemberService implements GetMemberUseCase {
             new MemberDetailInfo(
                 new MemberInfo(other.getMemberId(), other.getNickname(), other.getProfileUrl()),
                 other.getDescription(), nftRepository.countByMemberAndDeleted(other, false),
-                followRepository.countByFollowerIdAndStatus(memberId, true),
-                followRepository.countByFollowingIdAndStatus(memberId, true)
+                followRepository.countByFollowerMemberAndStatus(other, true),
+                followRepository.countByFollowingMemberAndStatus(other, true)
             ), getFollowUseCase.checkIsFollowed(member, other)
         );
     }

--- a/src/main/java/com/service/dida/domain/member/service/GetMemberService.java
+++ b/src/main/java/com/service/dida/domain/member/service/GetMemberService.java
@@ -1,9 +1,13 @@
 package com.service.dida.domain.member.service;
 
+import com.service.dida.domain.follow.repository.FollowRepository;
+import com.service.dida.domain.member.dto.MemberResponseDto.MemberDetailInfo;
+import com.service.dida.domain.member.dto.MemberResponseDto.MemberInfo;
 import com.service.dida.domain.member.dto.MemberResponseDto.WalletExists;
 import com.service.dida.domain.member.dto.SendAuthEmailDto;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.member.usecase.GetMemberUseCase;
+import com.service.dida.domain.nft.repository.NftRepository;
 import com.service.dida.global.util.mail.MailUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +17,8 @@ import org.springframework.stereotype.Service;
 public class GetMemberService implements GetMemberUseCase {
 
     private final MailUseCase mailUseCase;
+    private final FollowRepository followRepository;
+    private final NftRepository nftRepository;
 
     @Override
     public SendAuthEmailDto sendAuthMail(Member member) {
@@ -21,7 +27,19 @@ public class GetMemberService implements GetMemberUseCase {
 
     @Override
     public WalletExists isExistWallet(Member member) {
-        if(member.getWallet() == null) return new WalletExists(false);
-        else return new WalletExists(true);
+        if (member.getWallet() == null) {
+            return new WalletExists(false);
+        } else {
+            return new WalletExists(true);
+        }
+    }
+
+    @Override
+    public MemberDetailInfo getMemberDetailInfo(Member member) {
+        return new MemberDetailInfo(
+            new MemberInfo(member.getMemberId(), member.getNickname(), member.getProfileUrl()),
+            member.getDescription(), nftRepository.countByMemberAndDeleted(member, false),
+            followRepository.countByFollowerIdAndStatus(member.getMemberId(), true),
+            followRepository.countByFollowingIdAndStatus(member.getMemberId(), true));
     }
 }

--- a/src/main/java/com/service/dida/domain/member/usecase/GetMemberUseCase.java
+++ b/src/main/java/com/service/dida/domain/member/usecase/GetMemberUseCase.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.member.usecase;
 
 import com.service.dida.domain.member.dto.MemberResponseDto.MemberDetailInfo;
+import com.service.dida.domain.member.dto.MemberResponseDto.OtherMemberDetailInfo;
 import com.service.dida.domain.member.dto.MemberResponseDto.WalletExists;
 import com.service.dida.domain.member.dto.SendAuthEmailDto;
 import com.service.dida.domain.member.entity.Member;
@@ -12,4 +13,6 @@ public interface GetMemberUseCase {
     WalletExists isExistWallet(Member member);
 
     MemberDetailInfo getMemberDetailInfo(Member member);
+
+    OtherMemberDetailInfo getOtherMemberDetailInfo(Member member,Long memberId);
 }

--- a/src/main/java/com/service/dida/domain/member/usecase/GetMemberUseCase.java
+++ b/src/main/java/com/service/dida/domain/member/usecase/GetMemberUseCase.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.member.usecase;
 
+import com.service.dida.domain.member.dto.MemberResponseDto.MemberDetailInfo;
 import com.service.dida.domain.member.dto.MemberResponseDto.WalletExists;
 import com.service.dida.domain.member.dto.SendAuthEmailDto;
 import com.service.dida.domain.member.entity.Member;
@@ -9,4 +10,6 @@ public interface GetMemberUseCase {
     SendAuthEmailDto sendAuthMail(Member member);
 
     WalletExists isExistWallet(Member member);
+
+    MemberDetailInfo getMemberDetailInfo(Member member);
 }

--- a/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
+++ b/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
@@ -36,7 +36,18 @@ public class GetNftController {
     @GetMapping("/common/profile/nft")
     public ResponseEntity<PageResponseDto<List<ProfileNft>>> getProfileNftList(
         @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto) {
-        return new ResponseEntity<>(getNftUseCase.getProfileNftList(member, pageRequestDto),
+        return new ResponseEntity<>(getNftUseCase.getProfileNftList(member, null, pageRequestDto),
             HttpStatus.OK);
+    }
+
+    /**
+     * 다른유저 NFT 목록 보기 Api
+     */
+    @GetMapping("/common/profile/nft/{memberId}")
+    public ResponseEntity<PageResponseDto<List<ProfileNft>>> getOtherProfileNftList(
+        @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto,
+        @PathVariable(name = "memberId") Long memberId) {
+        return new ResponseEntity<>(
+            getNftUseCase.getProfileNftList(member, memberId, pageRequestDto), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
+++ b/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
@@ -2,13 +2,18 @@ package com.service.dida.domain.nft.controller;
 
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.dto.NftResponseDto.NftDetailInfo;
+import com.service.dida.domain.nft.dto.NftResponseDto.ProfileNft;
 import com.service.dida.domain.nft.usecase.GetNftUseCase;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
 import com.service.dida.global.config.security.auth.CurrentMember;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,5 +28,15 @@ public class GetNftController {
     public ResponseEntity<NftDetailInfo> getNftDetail(@CurrentMember Member member,
         @PathVariable(value = "nftId") Long nftId) {
         return new ResponseEntity<>(getNftUseCase.getNftDetail(member, nftId), HttpStatus.OK);
+    }
+
+    /**
+     * 내 NFT 목록 보기 Api
+     */
+    @GetMapping("/common/profile/nft")
+    public ResponseEntity<PageResponseDto<List<ProfileNft>>> getProfileNftList(
+        @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto) {
+        return new ResponseEntity<>(getNftUseCase.getProfileNftList(member, pageRequestDto),
+            HttpStatus.OK);
     }
 }

--- a/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
+++ b/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
@@ -43,7 +43,7 @@ public class GetNftController {
     /**
      * 다른유저 NFT 목록 보기 Api
      */
-    @GetMapping("/common/profile/nft/{memberId}")
+    @GetMapping("/profile/nft/{memberId}")
     public ResponseEntity<PageResponseDto<List<ProfileNft>>> getOtherProfileNftList(
         @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto,
         @PathVariable(name = "memberId") Long memberId) {

--- a/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
+++ b/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
@@ -29,4 +29,11 @@ public class NftResponseDto {
         private boolean followed;
         private boolean liked;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ProfileNft {
+        private NftInfo nftInfo;
+        private boolean liked;
+    }
 }

--- a/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
+++ b/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
@@ -3,6 +3,8 @@ package com.service.dida.domain.nft.repository;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -16,5 +18,8 @@ public interface NftRepository extends JpaRepository<Nft, Long> {
     @Query(value = "select n from Nft n LEFT JOIN FETCH n.market where n.nftId = :nftId and n.member = :member and n.deleted = false")
     Optional<Nft> findByNftIdWithDeletedAndMember(Member member, Long nftId);
 
-    Integer countByMemberAndDeleted(Member member,boolean deleted);
+    Integer countByMemberAndDeleted(Member member, boolean deleted);
+
+    @Query(value = "SELECT n FROM Nft n WHERE n.member = :member AND n.deleted = false")
+    Page<Nft> findAllNftsByMember(Member member, PageRequest pageRequest);
 }

--- a/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
+++ b/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
@@ -15,4 +15,6 @@ public interface NftRepository extends JpaRepository<Nft, Long> {
 
     @Query(value = "select n from Nft n LEFT JOIN FETCH n.market where n.nftId = :nftId and n.member = :member and n.deleted = false")
     Optional<Nft> findByNftIdWithDeletedAndMember(Member member, Long nftId);
+
+    Integer countByMemberAndDeleted(Member member,boolean deleted);
 }

--- a/src/main/java/com/service/dida/domain/nft/usecase/GetNftUseCase.java
+++ b/src/main/java/com/service/dida/domain/nft/usecase/GetNftUseCase.java
@@ -11,5 +11,5 @@ public interface GetNftUseCase {
 
     NftDetailInfo getNftDetail(Member member,Long nftId);
 
-    PageResponseDto<List<ProfileNft>> getProfileNftList(Member member, PageRequestDto pageRequestDto);
+    PageResponseDto<List<ProfileNft>> getProfileNftList(Member member,Long memberId, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/nft/usecase/GetNftUseCase.java
+++ b/src/main/java/com/service/dida/domain/nft/usecase/GetNftUseCase.java
@@ -2,8 +2,14 @@ package com.service.dida.domain.nft.usecase;
 
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.dto.NftResponseDto.NftDetailInfo;
+import com.service.dida.domain.nft.dto.NftResponseDto.ProfileNft;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import java.util.List;
 
 public interface GetNftUseCase {
 
     NftDetailInfo getNftDetail(Member member,Long nftId);
+
+    PageResponseDto<List<ProfileNft>> getProfileNftList(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/global/config/exception/errorCode/MemberErrorCode.java
+++ b/src/main/java/com/service/dida/global/config/exception/errorCode/MemberErrorCode.java
@@ -8,10 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
-    EMPTY_MEMBER("MEMBER_001", "존재하지 않는 사용자입니다.",HttpStatus.CONFLICT),
-    UN_REGISTERED_MEMBER("MEMBER_002", "",HttpStatus.OK),
-    DUPLICATE_MEMBER("MEMBER_003", "중복된 사용자입니다.",HttpStatus.CONFLICT),
-    DUPLICATE_NICKNAME("MEMBER_004", "중복된 닉네임입니다.",HttpStatus.CONFLICT);
+    EMPTY_MEMBER("MEMBER_001", "존재하지 않는 사용자입니다.", HttpStatus.CONFLICT),
+    UN_REGISTERED_MEMBER("MEMBER_002", "", HttpStatus.OK),
+    DUPLICATE_MEMBER("MEMBER_003", "중복된 사용자입니다.", HttpStatus.CONFLICT),
+    DUPLICATE_NICKNAME("MEMBER_004", "중복된 닉네임입니다.", HttpStatus.CONFLICT),
+    INVALID_MEMBER("MEMBER_005", "올바르지 않은 사용자입니다.", HttpStatus.BAD_REQUEST),
+    ;
     private final String errorCode;
     private final String message;
     private final HttpStatus status;


### PR DESCRIPTION
### 요약

- 사용자 프로필 및 팔로우 확인 Api 개발
### 상세 내용

- 내 프로필 확인하기 Api
- 내 프로필 NFT 목록 확인하기 Api
- 타인 프로필 확인하기 Api
- 타인 NFT 목록 확인하기 Api
- 다른 유저 팔로우 및 팔로우, 팔로잉 목록 확인하기 Api
- Follow의 memberId 부분을 member 로 변경 -> 팔로우 멤버들의 정보를 가져와야 하는데 id 값들을 가져온 후 다시 id에 맞는 유저정보를 가져온다면 너무나 비 효율적이라 수정하였습니다.
### 질문 및 이외 사항

- 
### 이슈 번호

- #11 #12 #13 #14 #15 #16 #17 