### PR TITLE
숨기기 API

### DIFF
--- a/src/main/java/com/service/dida/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/service/dida/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.comment.repository;
 
 import com.service.dida.domain.comment.Comment;
+import com.service.dida.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +12,11 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query(value = "SELECT c FROM Comment c WHERE c.post.postId = :postId AND c.deleted = false")
     Page<Comment> findByPostIdWithDeleted(Long postId, PageRequest pageRequest);
+
+    @Query(value = "SELECT c FROM Comment c WHERE c.post.postId = :postId AND c.deleted = false " +
+            "AND c.member NOT IN (SELECT mh.hideMember FROM MemberHide mh WHERE mh.member=:member) " +
+            "AND c NOT IN (SELECT ch.comment FROM CommentHide ch WHERE ch.member=:member)")
+    Page<Comment> findByPostIdWithDeletedWithoutHide(Member member, Long postId, PageRequest pageRequest);
 
     @Query(value = "SELECT c FROM Comment c WHERE c.deleted = false")
     Optional<Comment> findByCommentIdWithDeleted(Long postId);

--- a/src/main/java/com/service/dida/domain/comment/usecase/GetCommentUseCase.java
+++ b/src/main/java/com/service/dida/domain/comment/usecase/GetCommentUseCase.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface GetCommentUseCase {
     CommentResponseDto.GetCommentResponseDto makeGetCommentResForm(Member member, Comment comment, boolean needType);
     PageResponseDto<List<CommentResponseDto.GetCommentResponseDto>> makeCommentListForm(Member member, Page<Comment> comments);
-    List<CommentResponseDto.GetCommentResponseDto> getPreviewComments(Long postId);
+    List<CommentResponseDto.GetCommentResponseDto> getPreviewComments(Member member, Long postId);
     PageResponseDto<List<CommentResponseDto.GetCommentResponseDto>> getAllComments(Member member, Long postId, PageRequestDto pageRequestDto);
     String checkIsMe(Member member, Member owner);
 

--- a/src/main/java/com/service/dida/domain/hide/comment_hide/CommentHide.java
+++ b/src/main/java/com/service/dida/domain/hide/comment_hide/CommentHide.java
@@ -1,0 +1,39 @@
+package com.service.dida.domain.hide.comment_hide;
+
+import com.service.dida.domain.comment.Comment;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "comment_hide")
+public class CommentHide extends BaseEntity {
+    @Id
+    @Column(name = "comment_hide_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentHideId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Column(name = "status", nullable = false, columnDefinition = "boolean default true")
+    private boolean status;
+
+    public boolean changeStatus() {
+        this.status = !this.status;
+        return this.status;
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/comment_hide/controller/RegisterCommentHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/comment_hide/controller/RegisterCommentHideController.java
@@ -1,0 +1,31 @@
+package com.service.dida.domain.hide.comment_hide.controller;
+
+import com.service.dida.domain.hide.comment_hide.usecase.RegisterCommentHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RegisterCommentHideController {
+
+    private final RegisterCommentHideUseCase registerCommentHideUseCase;
+
+    /**
+     * 댓글 숨기기
+     * [POST] /common/comment/hide
+     */
+    @PostMapping("/common/comment/hide")
+    public ResponseEntity<Integer> hideComment(
+            @RequestParam("commentId") Long commentId, @CurrentMember Member member)
+            throws BaseException {
+        registerCommentHideUseCase.hideComment(member, commentId);
+        return new ResponseEntity<>(200, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/comment_hide/repository/CommentHideRepository.java
+++ b/src/main/java/com/service/dida/domain/hide/comment_hide/repository/CommentHideRepository.java
@@ -1,0 +1,13 @@
+package com.service.dida.domain.hide.comment_hide.repository;
+
+import com.service.dida.domain.comment.Comment;
+import com.service.dida.domain.hide.comment_hide.CommentHide;
+import com.service.dida.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentHideRepository extends JpaRepository<CommentHide, Long> {
+
+    Optional<CommentHide> findByMemberAndComment(Member member, Comment comment);
+}

--- a/src/main/java/com/service/dida/domain/hide/comment_hide/service/RegisterCommentHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/comment_hide/service/RegisterCommentHideService.java
@@ -1,0 +1,46 @@
+package com.service.dida.domain.hide.comment_hide.service;
+
+import com.service.dida.domain.comment.Comment;
+import com.service.dida.domain.comment.repository.CommentRepository;
+import com.service.dida.domain.hide.comment_hide.CommentHide;
+import com.service.dida.domain.hide.comment_hide.repository.CommentHideRepository;
+import com.service.dida.domain.hide.comment_hide.usecase.RegisterCommentHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.CommentErrorCode;
+import com.service.dida.global.config.exception.errorCode.HideErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterCommentHideService implements RegisterCommentHideUseCase {
+
+    private final CommentHideRepository hideRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void save(CommentHide hide) {
+        hideRepository.save(hide);
+    }
+
+    public void createCommentHide(Member member, Comment comment) {
+        save(CommentHide.builder()
+                .member(member)
+                .comment(comment)
+                .build());
+    }
+
+    @Override
+    @Transactional
+    public void hideComment(Member member, Long commentId) {
+        Comment comment = commentRepository.findByCommentIdWithDeleted(commentId)
+                .orElseThrow(() -> new BaseException(CommentErrorCode.EMPTY_COMMENT));
+        if (hideRepository.findByMemberAndComment(member, comment).isEmpty()) {
+            createCommentHide(member, comment);
+        } else {
+            throw new BaseException(HideErrorCode.ALREADY_HIDE);
+        }
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/comment_hide/usecase/RegisterCommentHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/comment_hide/usecase/RegisterCommentHideUseCase.java
@@ -1,0 +1,8 @@
+package com.service.dida.domain.hide.comment_hide.usecase;
+
+import com.service.dida.domain.member.entity.Member;
+
+public interface RegisterCommentHideUseCase {
+
+    void hideComment(Member member, Long commentId);
+}

--- a/src/main/java/com/service/dida/domain/hide/member_hide/controller/GetMemberHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/member_hide/controller/GetMemberHideController.java
@@ -1,0 +1,35 @@
+package com.service.dida.domain.hide.member_hide.controller;
+
+import com.service.dida.domain.hide.member_hide.usecase.GetMemberHideUseCase;
+import com.service.dida.domain.hide.member_hide.dto.MemberHideResponseDto.GetMemberHide;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class GetMemberHideController {
+
+    private final GetMemberHideUseCase getMemberHideUseCase;
+
+    /**
+     * Member 숨김 목록 조회
+     * [GET] /common/member/hide
+     */
+    @GetMapping("/common/member/hide")
+    public ResponseEntity<PageResponseDto<List<GetMemberHide>>> getNftHideNftList(
+            @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
+            throws BaseException {
+        return new ResponseEntity<>(getMemberHideUseCase.getMemberHideList(member, pageRequestDto), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/member_hide/controller/UpdateMemberHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/member_hide/controller/UpdateMemberHideController.java
@@ -1,0 +1,31 @@
+package com.service.dida.domain.hide.member_hide.controller;
+
+import com.service.dida.domain.hide.member_hide.usecase.UpdateMemberHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UpdateMemberHideController {
+
+    private final UpdateMemberHideUseCase updateMemberHideUseCase;
+
+    /**
+     * Member 숨기기 취소
+     * [DELETE] /common/member/hide
+     */
+    @DeleteMapping("/common/member/hide")
+    public ResponseEntity<Integer> unhideMember(
+            @RequestParam("memberId") Long memberId, @CurrentMember Member member)
+            throws BaseException {
+        updateMemberHideUseCase.unhideMember(member, memberId);
+        return new ResponseEntity<>(200, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/member_hide/dto/MemberHideResponseDto.java
+++ b/src/main/java/com/service/dida/domain/hide/member_hide/dto/MemberHideResponseDto.java
@@ -1,4 +1,16 @@
 package com.service.dida.domain.hide.member_hide.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 public class MemberHideResponseDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class GetMemberHide {
+        private Long memberId;
+        private String nickname;
+        private String profileUrl;
+        private int nftCnt;
+    }
 }

--- a/src/main/java/com/service/dida/domain/hide/member_hide/repository/MemberHideRepository.java
+++ b/src/main/java/com/service/dida/domain/hide/member_hide/repository/MemberHideRepository.java
@@ -2,6 +2,8 @@ package com.service.dida.domain.hide.member_hide.repository;
 
 import com.service.dida.domain.hide.member_hide.MemberHide;
 import com.service.dida.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +11,6 @@ import java.util.Optional;
 public interface MemberHideRepository extends JpaRepository<MemberHide, Long> {
 
     Optional<MemberHide> findByMemberAndHideMember(Member member, Member hideMember);
+
+    Page<MemberHide> findByMember(Member member, PageRequest pageRequest);
 }

--- a/src/main/java/com/service/dida/domain/hide/member_hide/service/GetMemberHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/member_hide/service/GetMemberHideService.java
@@ -1,0 +1,52 @@
+package com.service.dida.domain.hide.member_hide.service;
+
+import com.service.dida.domain.hide.member_hide.MemberHide;
+import com.service.dida.domain.hide.member_hide.dto.MemberHideResponseDto.GetMemberHide;
+import com.service.dida.domain.hide.member_hide.repository.MemberHideRepository;
+import com.service.dida.domain.hide.member_hide.usecase.GetMemberHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.repository.NftRepository;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetMemberHideService implements GetMemberHideUseCase {
+
+    private final MemberHideRepository memberHideRepository;
+    private final NftRepository nftRepository;
+
+    /**
+     * Member 숨김 목록 조회에서 공통으로 사용 될 PageRequest 를 정의하는 함수
+     */
+    public PageRequest pageReq(PageRequestDto pageRequestDto) {
+        // pageRequest 는 원하는 page, 한 page 당 size, 최신 순서 정렬 이라는 요청을 담고 있다.
+        return PageRequest.of(pageRequestDto.getPage(), pageRequestDto.getPageSize()
+                , Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+    public GetMemberHide makeGetMemberHideForm(Member hideMember) {
+        return new GetMemberHide(hideMember.getMemberId(),
+                hideMember.getNickname(), hideMember.getProfileUrl(),
+                nftRepository.countByMemberAndDeleted(hideMember, false));
+    }
+
+    @Override
+    public PageResponseDto<List<GetMemberHide>> getMemberHideList(Member member, PageRequestDto pageRequestDto) {
+        Page<MemberHide> hides = memberHideRepository.findByMember(member, pageReq(pageRequestDto));
+        List<GetMemberHide> res = new ArrayList<>();
+
+        hides.forEach(h -> res.add(makeGetMemberHideForm(h.getHideMember())));
+
+        return new PageResponseDto<>(
+                hides.getNumber(), hides.getSize(), hides.hasNext(), res);
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/member_hide/service/UpdateMemberHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/member_hide/service/UpdateMemberHideService.java
@@ -1,0 +1,33 @@
+package com.service.dida.domain.hide.member_hide.service;
+
+import com.service.dida.domain.hide.member_hide.MemberHide;
+import com.service.dida.domain.hide.member_hide.repository.MemberHideRepository;
+import com.service.dida.domain.hide.member_hide.usecase.UpdateMemberHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.member.repository.MemberRepository;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.HideErrorCode;
+import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateMemberHideService implements UpdateMemberHideUseCase {
+
+    private final MemberRepository memberRepository;
+    private final MemberHideRepository hideRepository;
+    @Override
+    @Transactional
+    public void unhideMember(Member member, Long memberId) {
+        Member hideMember = memberRepository.findByMemberIdWithDeleted(memberId)
+                .orElseThrow(() -> new BaseException(MemberErrorCode.INVALID_MEMBER));
+        MemberHide hide = hideRepository.findByMemberAndHideMember(member, hideMember).orElse(null);
+        if(hide == null) { //비어있다면 숨기지 않은 카드이므로 예외 처리
+            throw new BaseException(HideErrorCode.NOT_HIDE);
+        } else {
+            hideRepository.delete(hide);
+        }
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/member_hide/usecase/GetMemberHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/member_hide/usecase/GetMemberHideUseCase.java
@@ -1,0 +1,12 @@
+package com.service.dida.domain.hide.member_hide.usecase;
+
+import com.service.dida.domain.hide.member_hide.dto.MemberHideResponseDto;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+
+import java.util.List;
+
+public interface GetMemberHideUseCase {
+    PageResponseDto<List<MemberHideResponseDto.GetMemberHide>> getMemberHideList(Member member, PageRequestDto pageRequestDto);
+}

--- a/src/main/java/com/service/dida/domain/hide/member_hide/usecase/UpdateMemberHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/member_hide/usecase/UpdateMemberHideUseCase.java
@@ -1,0 +1,8 @@
+package com.service.dida.domain.hide.member_hide.usecase;
+
+import com.service.dida.domain.member.entity.Member;
+
+public interface UpdateMemberHideUseCase {
+
+    void unhideMember(Member member, Long memberId);
+}

--- a/src/main/java/com/service/dida/domain/hide/nft_hide/controller/RegisterNftHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/nft_hide/controller/RegisterNftHideController.java
@@ -21,10 +21,10 @@ public class RegisterNftHideController {
      * [POST] /common/nft/hide
      */
     @PostMapping("/common/nft/hide")
-    public ResponseEntity<Integer> hideCard(
+    public ResponseEntity<Integer> hideNft(
             @RequestParam("nftId") Long nftId, @CurrentMember Member member)
             throws BaseException {
-        registerNftHideUseCase.hideCard(member, nftId);
+        registerNftHideUseCase.hideNft(member, nftId);
         return new ResponseEntity<>(200, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/service/dida/domain/hide/nft_hide/service/RegisterNftHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/nft_hide/service/RegisterNftHideService.java
@@ -35,7 +35,7 @@ public class RegisterNftHideService implements RegisterNftHideUseCase {
 
     @Override
     @Transactional
-    public void hideCard(Member member, Long nftId) {
+    public void hideNft(Member member, Long nftId) {
         Nft nft = nftRepository.findByNftIdWithDeleted(nftId)
                 .orElseThrow(() -> new BaseException(NftErrorCode.EMPTY_NFT));
         if (hideRepository.findByMemberAndNft(member, nft).isEmpty()) {

--- a/src/main/java/com/service/dida/domain/hide/nft_hide/usecase/RegisterNftHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/nft_hide/usecase/RegisterNftHideUseCase.java
@@ -3,5 +3,5 @@ package com.service.dida.domain.hide.nft_hide.usecase;
 import com.service.dida.domain.member.entity.Member;
 
 public interface RegisterNftHideUseCase {
-    void hideCard(Member member, Long nftId);
+    void hideNft(Member member, Long nftId);
 }

--- a/src/main/java/com/service/dida/domain/hide/post_hide/PostHide.java
+++ b/src/main/java/com/service/dida/domain/hide/post_hide/PostHide.java
@@ -1,0 +1,39 @@
+package com.service.dida.domain.hide.post_hide;
+
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.post.Post;
+import com.service.dida.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "post_hide")
+public class PostHide extends BaseEntity {
+    @Id
+    @Column(name = "post_hide_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postHideId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(name = "status", nullable = false, columnDefinition = "boolean default true")
+    private boolean status;
+
+    public boolean changeStatus() {
+        this.status = !this.status;
+        return this.status;
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/post_hide/controller/RegisterPostHideController.java
+++ b/src/main/java/com/service/dida/domain/hide/post_hide/controller/RegisterPostHideController.java
@@ -1,0 +1,30 @@
+package com.service.dida.domain.hide.post_hide.controller;
+
+import com.service.dida.domain.hide.post_hide.usecase.RegisterPostHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RegisterPostHideController {
+
+    private final RegisterPostHideUseCase registerPostHideUseCase;
+    /**
+     * 게시글 숨기기
+     * [POST] /common/post/hide
+     */
+    @PostMapping("/common/post/hide")
+    public ResponseEntity<Integer> hidePost(
+            @RequestParam("postId") Long postId, @CurrentMember Member member)
+            throws BaseException {
+        registerPostHideUseCase.hidePost(member, postId);
+        return new ResponseEntity<>(200, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/post_hide/repository/PostHideRepository.java
+++ b/src/main/java/com/service/dida/domain/hide/post_hide/repository/PostHideRepository.java
@@ -1,0 +1,13 @@
+package com.service.dida.domain.hide.post_hide.repository;
+
+import com.service.dida.domain.hide.post_hide.PostHide;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostHideRepository extends JpaRepository<PostHide, Long> {
+
+    Optional<PostHide> findByMemberAndPost(Member member, Post post);
+}

--- a/src/main/java/com/service/dida/domain/hide/post_hide/service/RegisterPostHideService.java
+++ b/src/main/java/com/service/dida/domain/hide/post_hide/service/RegisterPostHideService.java
@@ -1,0 +1,46 @@
+package com.service.dida.domain.hide.post_hide.service;
+
+import com.service.dida.domain.hide.post_hide.PostHide;
+import com.service.dida.domain.hide.post_hide.repository.PostHideRepository;
+import com.service.dida.domain.hide.post_hide.usecase.RegisterPostHideUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.post.Post;
+import com.service.dida.domain.post.repository.PostRepository;
+import com.service.dida.global.config.exception.BaseException;
+import com.service.dida.global.config.exception.errorCode.HideErrorCode;
+import com.service.dida.global.config.exception.errorCode.PostErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterPostHideService implements RegisterPostHideUseCase {
+
+    private final PostHideRepository hideRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public void save(PostHide hide) {
+        hideRepository.save(hide);
+    }
+
+    public void createPostHide(Member member, Post post) {
+        save(PostHide.builder()
+                .member(member)
+                .post(post)
+                .build());
+    }
+
+    @Override
+    @Transactional
+    public void hidePost(Member member, Long postId) {
+        Post post = postRepository.findByPostIdWithDeleted(postId)
+                .orElseThrow(() -> new BaseException(PostErrorCode.EMPTY_POST));
+        if (hideRepository.findByMemberAndPost(member, post).isEmpty()) {
+            createPostHide(member, post);
+        } else {
+            throw new BaseException(HideErrorCode.ALREADY_HIDE);
+        }
+    }
+}

--- a/src/main/java/com/service/dida/domain/hide/post_hide/usecase/RegisterPostHideUseCase.java
+++ b/src/main/java/com/service/dida/domain/hide/post_hide/usecase/RegisterPostHideUseCase.java
@@ -1,0 +1,8 @@
+package com.service.dida.domain.hide.post_hide.usecase;
+
+import com.service.dida.domain.member.entity.Member;
+
+public interface RegisterPostHideUseCase {
+
+    void hidePost(Member member, Long postId);
+}

--- a/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/service/dida/domain/post/repository/PostRepository.java
@@ -4,7 +4,6 @@ import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.post.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -18,14 +17,19 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByPostIdWithDeleted(Long postId);
     Optional<Post> findByPostId(Long postId);
 
-    /**
-    @Query(value = "SELECT p FROM Post p, (SELECT h FROM NftHide h WHERE h.member = :member AND p.nft = h.nft) " +
-            "WHERE p.deleted = false AND h.nft != p.nft")
-    Page<Post> findAllWithDeleted(Member member, PageRequest pageRequest);
-     */
+    @Query(value = "SELECT p FROM Post p WHERE p.deleted = false " +
+            "AND p.member NOT IN (SELECT mh.hideMember FROM MemberHide mh WHERE mh.member=:member) " +
+            "AND p NOT IN (SELECT ph.post FROM PostHide ph WHERE ph.member=:member) " +
+            "AND p.nft NOT IN (SELECT nh.nft FROM NftHide nh WHERE nh.member=:member)")
+    Page<Post> findAllWithDeletedWithoutHide(Member member, PageRequest pageRequest);
 
     @Query(value = "SELECT p FROM Post p WHERE p.deleted = false")
     Page<Post> findAllWithDeleted(PageRequest pageRequest);
+
+    @Query(value = "SELECT p FROM Post p WHERE p.nft.nftId = :nftId AND p.deleted = false " +
+            "AND p.member NOT IN (SELECT mh.hideMember FROM MemberHide mh WHERE mh.member=:member) " +
+            "AND p NOT IN (SELECT ph.post FROM PostHide ph WHERE ph.member=:member) ")
+    Page<Post> findByNftIdWithDeletedWithoutHide(Member member, Long nftId, PageRequest pageRequest);
 
     @Query(value = "SELECT p FROM Post p WHERE p.nft.nftId = :nftId AND p.deleted = false")
     Page<Post> findByNftIdWithDeleted(Long nftId, PageRequest pageRequest);

--- a/src/main/java/com/service/dida/domain/report/service/RegisterReportService.java
+++ b/src/main/java/com/service/dida/domain/report/service/RegisterReportService.java
@@ -2,6 +2,10 @@ package com.service.dida.domain.report.service;
 
 import com.service.dida.domain.comment.Comment;
 import com.service.dida.domain.comment.repository.CommentRepository;
+import com.service.dida.domain.hide.comment_hide.usecase.RegisterCommentHideUseCase;
+import com.service.dida.domain.hide.member_hide.usecase.RegisterMemberHideUseCase;
+import com.service.dida.domain.hide.nft_hide.usecase.RegisterNftHideUseCase;
+import com.service.dida.domain.hide.post_hide.usecase.RegisterPostHideUseCase;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.member.repository.MemberRepository;
 import com.service.dida.domain.nft.Nft;
@@ -34,6 +38,10 @@ public class RegisterReportService implements RegisterReportUseCase {
     private final CommentRepository commentRepository;
     private final NftRepository nftRepository;
     private final MailUseCase mailUseCase;
+    private final RegisterMemberHideUseCase registerMemberHideUseCase;
+    private final RegisterNftHideUseCase registerNftHideUseCase;
+    private final RegisterPostHideUseCase registerPostHideUseCase;
+    private final RegisterCommentHideUseCase registerCommentHideUseCase;
 
     @Transactional
     public void save(Report report) {
@@ -74,7 +82,7 @@ public class RegisterReportService implements RegisterReportUseCase {
 
         createReport(member, registerReport, ReportType.USER);
         reportedMember.plusReportCnt();
-        // 숨김 처리 추가 필요
+        registerMemberHideUseCase.hideMember(member, registerReport.getReportedId());
 
         // 누적 신고 횟수가 기준치 이상이라면 유저 임시 삭제 처리 및 이메일 전송
         if (reportedMember.getReportCnt() >= REPORT_STANDARD) {
@@ -94,7 +102,7 @@ public class RegisterReportService implements RegisterReportUseCase {
 
         createReport(member, registerReport, ReportType.POST);
         reportedPost.plusReportCnt();
-        // 숨김 처리 추가 필요
+        registerPostHideUseCase.hidePost(member, registerReport.getReportedId());
 
         // 누적 신고 횟수가 기준치 이상이라면 삭제
         if (reportedPost.getReportCnt() >= REPORT_STANDARD) {
@@ -113,7 +121,7 @@ public class RegisterReportService implements RegisterReportUseCase {
 
         createReport(member, registerReport, ReportType.COMMENT);
         reportedComment.plusReportCnt();
-        // 숨김 처리 추가 필요
+        registerCommentHideUseCase.hideComment(member, registerReport.getReportedId());
 
         // 누적 신고 횟수가 기준치 이상이라면 삭제
         if (reportedComment.getReportCnt() >= REPORT_STANDARD) {
@@ -132,7 +140,7 @@ public class RegisterReportService implements RegisterReportUseCase {
 
         createReport(member, registerReport, ReportType.NFT);
         reportedNft.plusReportCnt();
-        // 숨김 처리 추가 필요
+        registerNftHideUseCase.hideNft(member, registerReport.getReportedId());
 
         // 누적 신고 횟수가 기준치 이상이라면 삭제
         if (reportedNft.getReportCnt() >= REPORT_STANDARD) {


### PR DESCRIPTION
### 요약

- 멤버 숨김 목록 조회 API
- 멤버 숨김 취소 API
- 게시글 숨기기 API
- 댓글 숨기기 API
- 신고 후 즉시 숨김되도록 처리
- 게시글 또는 댓글 조회에서 숨김 처리한 리소스가 더이상 보이지 않도록 처리
### 상세 내용

- 게시글과 댓글은 지금 기준으로는 숨김 취소나 목록 조회가 필요하지 않은 것으로 알아서 숨기기만 만들어 놨습니다!
### 질문 및 이외 사항

- WithoutHide 붙은 쿼리문에서 member가 null일 때 오류가 나더라고요..! 그래서 우선은 쿼리 두 개로 했습니닷 ㅠㅠ 더 좋은 방법이 있나 생각해보겠습니다!
### 이슈 번호

- #