### PR TITLE
메인 화면 더보기 API 구현

### DIFF
--- a/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
+++ b/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
@@ -1,7 +1,7 @@
 package com.service.dida.domain.market.controller;
 
 import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSoldOut;
-import com.service.dida.domain.market.dto.MarketResponseDto.MoreHotSellers;
+import com.service.dida.domain.market.dto.MarketResponseDto.MoreHotSeller;
 import com.service.dida.domain.market.usecase.GetMarketUseCase;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.global.common.dto.PageRequestDto;
@@ -37,10 +37,11 @@ public class GetMarketController {
      * [GET] /hot-sellers
      */
     @GetMapping("/hot-sellers")
-    public ResponseEntity<PageResponseDto<List<MoreHotSellers>>> getMoreHotSellers(
+    public ResponseEntity<PageResponseDto<List<MoreHotSeller>>> getMoreHotSellers(
             @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
             throws BaseException {
         return new ResponseEntity<>(getMarketUseCase.getMoreHotSellers(member, pageRequestDto),
                 HttpStatus.OK);
     }
+
 }

--- a/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
+++ b/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.market.controller;
 
+import com.service.dida.domain.market.dto.MarketResponseDto.GetRecentNft;
 import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSoldOut;
 import com.service.dida.domain.market.dto.MarketResponseDto.MoreHotSeller;
 import com.service.dida.domain.market.usecase.GetMarketUseCase;
@@ -44,4 +45,15 @@ public class GetMarketController {
                 HttpStatus.OK);
     }
 
+    /**
+     * 최신 NFT 더보기
+     * [GET] /recent-nfts
+     */
+    @GetMapping("/recent-nfts")
+    public ResponseEntity<PageResponseDto<List<GetRecentNft>>> getMoreRecentNfts(
+            @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
+            throws BaseException {
+        return new ResponseEntity<>(getMarketUseCase.getMoreRecentNfts(member, pageRequestDto),
+                HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
+++ b/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
@@ -1,15 +1,21 @@
 package com.service.dida.domain.market.controller;
 
 import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSoldOut;
+import com.service.dida.domain.market.dto.MarketResponseDto.MoreHotSellers;
 import com.service.dida.domain.market.usecase.GetMarketUseCase;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
 import com.service.dida.global.config.exception.BaseException;
 import com.service.dida.global.config.security.auth.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +30,17 @@ public class GetMarketController {
     public ResponseEntity<GetMainPageWithoutSoldOut> getMainPage(@CurrentMember Member member)
             throws BaseException {
         return new ResponseEntity<>(getMarketUseCase.getMainPage(member), HttpStatus.OK);
+    }
+
+    /**
+     * Hot Seller 더보기
+     * [GET] /hot-sellers
+     */
+    @GetMapping("/hot-sellers")
+    public ResponseEntity<PageResponseDto<List<MoreHotSellers>>> getMoreHotSellers(
+            @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
+            throws BaseException {
+        return new ResponseEntity<>(getMarketUseCase.getMoreHotSellers(member, pageRequestDto),
+                HttpStatus.OK);
     }
 }

--- a/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
+++ b/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
@@ -56,4 +56,16 @@ public class GetMarketController {
         return new ResponseEntity<>(getMarketUseCase.getMoreRecentNfts(member, pageRequestDto),
                 HttpStatus.OK);
     }
+
+    /**
+     * 활발한 활동 더보기
+     * [GET] /hot-members
+     */
+    @GetMapping("/hot-members")
+    public ResponseEntity<PageResponseDto<List<MoreHotSeller>>> getMoreHotMembers(
+            @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
+            throws BaseException {
+        return new ResponseEntity<>(getMarketUseCase.getMoreHotMembers(member, pageRequestDto),
+                HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
+++ b/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
@@ -2,7 +2,7 @@ package com.service.dida.domain.market.controller;
 
 import com.service.dida.domain.market.dto.MarketResponseDto.GetRecentNft;
 import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSoldOut;
-import com.service.dida.domain.market.dto.MarketResponseDto.MoreHotSeller;
+import com.service.dida.domain.market.dto.MarketResponseDto.MoreHotMember;
 import com.service.dida.domain.market.usecase.GetMarketUseCase;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.global.common.dto.PageRequestDto;
@@ -38,7 +38,7 @@ public class GetMarketController {
      * [GET] /hot-sellers
      */
     @GetMapping("/hot-sellers")
-    public ResponseEntity<PageResponseDto<List<MoreHotSeller>>> getMoreHotSellers(
+    public ResponseEntity<PageResponseDto<List<MoreHotMember>>> getMoreHotSellers(
             @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
             throws BaseException {
         return new ResponseEntity<>(getMarketUseCase.getMoreHotSellers(member, pageRequestDto),
@@ -62,7 +62,7 @@ public class GetMarketController {
      * [GET] /hot-members
      */
     @GetMapping("/hot-members")
-    public ResponseEntity<PageResponseDto<List<MoreHotSeller>>> getMoreHotMembers(
+    public ResponseEntity<PageResponseDto<List<MoreHotMember>>> getMoreHotMembers(
             @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
             throws BaseException {
         return new ResponseEntity<>(getMarketUseCase.getMoreHotMembers(member, pageRequestDto),

--- a/src/main/java/com/service/dida/domain/market/dto/MarketResponseDto.java
+++ b/src/main/java/com/service/dida/domain/market/dto/MarketResponseDto.java
@@ -61,8 +61,8 @@ public class MarketResponseDto {
 
     @Getter
     @AllArgsConstructor
-    public static class MoreHotSeller {
-        private GetHotMember sellerInfo;
+    public static class MoreHotMember {
+        private GetHotMember memberInfo;
         private List<String> nftImgUrl;
     }
 }

--- a/src/main/java/com/service/dida/domain/market/dto/MarketResponseDto.java
+++ b/src/main/java/com/service/dida/domain/market/dto/MarketResponseDto.java
@@ -53,9 +53,16 @@ public class MarketResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetMainPageWithoutSoldOut {
-        List<GetHotItem> getHotItems;
-        List<GetHotSeller> getHotSellers;
-        List<GetRecentNft> getRecentNfts;
-        List<GetHotMember> getHotMembers;
+        private List<GetHotItem> getHotItems;
+        private List<GetHotSeller> getHotSellers;
+        private List<GetRecentNft> getRecentNfts;
+        private List<GetHotMember> getHotMembers;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MoreHotSellers{
+        private GetHotMember sellerInfo;
+        private List<String> nftImgUrl;
     }
 }

--- a/src/main/java/com/service/dida/domain/market/dto/MarketResponseDto.java
+++ b/src/main/java/com/service/dida/domain/market/dto/MarketResponseDto.java
@@ -61,7 +61,7 @@ public class MarketResponseDto {
 
     @Getter
     @AllArgsConstructor
-    public static class MoreHotSellers{
+    public static class MoreHotSeller {
         private GetHotMember sellerInfo;
         private List<String> nftImgUrl;
     }

--- a/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
+++ b/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
@@ -175,7 +175,7 @@ public class GetMarketService implements GetMarketUseCase {
         return new GetMainPageWithoutSoldOut(hotItems, hotSellers, recentNfts, hotMembers);
     }
 
-    public MoreHotSellers makeMoreHotSellersForm(Member member, Member seller) {
+    public MoreHotSeller makeMoreHotSellersForm(Member member, Member seller) {
         List<String> nftImgUrls;
         if (member != null) {
             nftImgUrls = nftRepository.getRecentNftImgUrlWithoutHide(member, seller,
@@ -184,11 +184,11 @@ public class GetMarketService implements GetMarketUseCase {
             nftImgUrls = nftRepository.getRecentNftImgUrl(seller,
                     PageRequest.of(0, 3)).orElse(null);
         }
-        return new MoreHotSellers(makeGetHotMemberForm(member, seller), nftImgUrls);
+        return new MoreHotSeller(makeGetHotMemberForm(member, seller), nftImgUrls);
     }
 
-    public PageResponseDto<List<MoreHotSellers>> makeMoreHotSellersListForm(Member member, Page<Long> hotSellers) {
-        List<MoreHotSellers> res = new ArrayList<>();
+    public PageResponseDto<List<MoreHotSeller>> makeMoreHotSellersListForm(Member member, Page<Long> hotSellers) {
+        List<MoreHotSeller> res = new ArrayList<>();
         hotSellers.forEach(sellerId -> res.add(makeMoreHotSellersForm(member,
                 memberRepository.findByMemberIdWithDeleted(sellerId)
                         .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER)))));
@@ -197,7 +197,7 @@ public class GetMarketService implements GetMarketUseCase {
     }
 
     @Override
-    public PageResponseDto<List<MoreHotSellers>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto) {
+    public PageResponseDto<List<MoreHotSeller>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto) {
         Page<Long> sellers;
         if (member != null) { // 로그인 했으면 숨김 리소스 제외
             sellers = transactionRepository.getHotSellersWithoutHide(member,

--- a/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
+++ b/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
@@ -46,178 +46,6 @@ public class GetMarketService implements GetMarketUseCase {
                 , Sort.by(Sort.Direction.DESC, "createdAt"));
     }
 
-    public boolean checkIsMe(Long memberId, Long ownerId) {
-        return Objects.equals(memberId, ownerId);
-    }
-
-    public String likeCountToString(long likeCount) {
-        if (likeCount >= 1000) {
-            return likeCount / 1000 + "K";
-        } else return Long.toString(likeCount);
-    }
-
-    /**
-     * Nft Entity를 넘겨 받아 GetHotItem DTO 형태로 만드는 함수
-     */
-    public GetHotItem makeHotItemForm(Nft nft) {
-        return new GetHotItem(nft.getNftId(), nft.getImgUrl(), nft.getTitle(), nft.getPrice(),
-                likeCountToString(likeRepository.getLikeCountsByNftId(nft).orElse(0L)));
-    }
-
-    /**
-     * Member Entity를 넘겨 받아 GetHotSeller DTO 형태로 만드는 함수
-     */
-    public GetHotSeller makeHotSellerForm(Member member, Member owner) {
-        List<String> nftImgUrls;
-        String nftImgUrl = "";
-        if (member != null) {
-            nftImgUrls = nftRepository.getRecentNftImgUrlWithoutHide(member, owner
-                    , PageRequest.of(0, 1)).orElse(null);
-        } else {
-            nftImgUrls = nftRepository.getRecentNftImgUrl(owner,
-                    PageRequest.of(0, 1)).orElse(null);
-        }
-        if (nftImgUrls != null) { // getRecentNftImgUrl 을 페이징으로 바꾸며 추가한 코드
-            nftImgUrl = nftImgUrls.get(0);
-        }
-        return new GetHotSeller(owner.getMemberId(), owner.getNickname(),
-                owner.getProfileUrl(), nftImgUrl);
-
-    }
-
-    /**
-     * Nft Entity를 넘겨 받아 GetRecentNft DTO 형태로 만드는 함수
-     */
-    public GetRecentNft makeGetRecentNftForm(Member member, Nft nft) {
-        boolean liked = false;
-        if (member != null) {
-            liked = getLikeUseCase.checkIsLiked(member, nft);
-        }
-        return new GetRecentNft(nft.getNftId(), nft.getTitle(), nft.getMember().getNickname(),
-                nft.getImgUrl(), nft.getPrice(), liked);
-    }
-
-    /**
-     * Member Entity를 넘겨 받아 GetHotMember DTO 형태로 만드는 함수
-     */
-    public GetHotMember makeGetHotMemberForm(Member member, Member target) {
-        boolean followed = false;
-        boolean isMe = false;
-        if (member != null) {
-            followed = getFollowUseCase.checkIsFollowed(member, target);
-            isMe = checkIsMe(member.getMemberId(), target.getMemberId());
-        }
-        return new GetHotMember(target.getMemberId(), target.getNickname(), target.getProfileUrl(),
-                nftRepository.countByMemberWithDeleted(target).orElse(0L), followed, isMe);
-    }
-
-    /**
-     * Member Entity를 넘겨 받아 MoreHoMember DTO 형태로 만드는 함수
-     */
-    public MoreHotMember makeMoreHotMembersForm(Member member, Member target, int limit) {
-        List<String> nftImgUrls;
-        if (member != null) {
-            nftImgUrls = nftRepository.getRecentNftImgUrlWithoutHide(member, target,
-                    PageRequest.of(0, limit)).orElse(null);
-        } else {
-            nftImgUrls = nftRepository.getRecentNftImgUrl(target,
-                    PageRequest.of(0, limit)).orElse(null);
-        }
-        return new MoreHotMember(makeGetHotMemberForm(member, target), nftImgUrls);
-    }
-
-    /**
-     * Page 를 넘겨 받아 MoreHotSeller List를 만드는 함수
-     * PageResponseDto로 반환
-     */
-    public PageResponseDto<List<MoreHotMember>> makeMoreHotMembersListForm(Member member, Page<Long> hotSellers, int limit) {
-        List<MoreHotMember> res = new ArrayList<>();
-        hotSellers.forEach(sellerId -> res.add(makeMoreHotMembersForm(member,
-                memberRepository.findByMemberIdWithDeleted(sellerId)
-                        .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER)), limit)));
-        return new PageResponseDto<>(
-                hotSellers.getNumber(), hotSellers.getSize(), hotSellers.hasNext(), res);
-    }
-
-    /**
-     * Page 를 넘겨 받아 GetRecentNft List를 만드는 함수
-     * PageResponseDto로 반환
-     */
-    public PageResponseDto<List<GetRecentNft>> makeMoreRecentNftsListForm(Member member, Page<Nft> nfts) {
-        List<GetRecentNft> res = new ArrayList<>();
-        nfts.forEach(nft -> res.add(makeGetRecentNftForm(member, nft)));
-        return new PageResponseDto<>(
-                nfts.getNumber(), nfts.getSize(), nfts.hasNext(), res);
-    }
-
-    public List<GetHotItem> getHotItems(Member member) {
-        List<GetHotItem> hotItems = new ArrayList<>();
-        List<Nft> nfts;
-        if (member != null) { // 로그인 했으면 숨김 리소스 제외
-            nfts = likeRepository.getHotItemsWithoutHide(member).orElse(null);
-        } else {
-            nfts = likeRepository.getHotItems().orElse(null);
-        }
-        if (nfts != null) {
-            for (Nft nft : nfts) {
-                hotItems.add(makeHotItemForm(nft));
-            }
-        }
-        return hotItems;
-    }
-
-    public List<GetHotSeller> getHotSellers(Member member) {
-        List<GetHotSeller> hotSellers = new ArrayList<>();
-        Page<Long> sellers;
-        if (member != null) { // 로그인 했으면 숨김 리소스 제외
-            sellers = transactionRepository.getHotSellersWithoutHide(member,
-                    LocalDateTime.now().minusDays(7), PageRequest.of(0, 4));
-        } else {
-            sellers = transactionRepository.getHotSellers(
-                    LocalDateTime.now().minusDays(7), PageRequest.of(0, 4));
-        }
-        if (sellers != null) {
-            for (Long sellerId : sellers) {
-                Member seller = memberRepository.findByMemberIdWithDeleted(sellerId)
-                        .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
-                hotSellers.add(makeHotSellerForm(member, seller));
-            }
-        }
-        return hotSellers;
-    }
-
-    public List<GetRecentNft> getRecentNfts(Member member) {
-        List<GetRecentNft> recentNfts = new ArrayList<>();
-        Page<Nft> nfts;
-        if (member != null) { // 로그인 했으면 숨김 리소스 제외
-            nfts = nftRepository.getRecentNftsWithoutHide(member, PageRequest.of(0, 3));
-        } else {
-            nfts = nftRepository.getRecentNfts(PageRequest.of(0, 3));
-        }
-        nfts.forEach(nft -> recentNfts.add(makeGetRecentNftForm(member, nft)));
-        return recentNfts;
-    }
-
-    public List<GetHotMember> getHotMembers(Member member) {
-        List<GetHotMember> hotMembers = new ArrayList<>();
-        Page<Long> members;
-        if (member != null) { // 로그인 했으면 숨김 리소스 제외
-            members = transactionRepository.getHotMembersWithoutHide(member, LocalDateTime.now().minusDays(30),
-                    PageRequest.of(0, 3));
-        } else {
-            members = transactionRepository.getHotMembers(LocalDateTime.now().minusDays(30),
-                    PageRequest.of(0, 3));
-        }
-        if (members != null) {
-            for (Long memberId : members) {
-                Member hotMember = memberRepository.findByMemberIdWithDeleted(memberId)
-                        .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
-                hotMembers.add(makeGetHotMemberForm(member, hotMember));
-            }
-        }
-        return hotMembers;
-    }
-
     @Override
     public GetMainPageWithoutSoldOut getMainPage(Member member) {
         List<GetHotItem> hotItems = getHotItems(member);
@@ -278,4 +106,174 @@ public class GetMarketService implements GetMarketUseCase {
         return makeMoreRecentNftsListForm(member, nfts);
     }
 
+    private List<GetHotItem> getHotItems(Member member) {
+        List<GetHotItem> hotItems = new ArrayList<>();
+        List<Nft> nfts;
+        if (member != null) { // 로그인 했으면 숨김 리소스 제외
+            nfts = likeRepository.getHotItemsWithoutHide(member).orElse(null);
+        } else {
+            nfts = likeRepository.getHotItems().orElse(null);
+        }
+        if (nfts != null) {
+            for (Nft nft : nfts) {
+                hotItems.add(makeHotItemForm(nft));
+            }
+        }
+        return hotItems;
+    }
+
+    private List<GetHotSeller> getHotSellers(Member member) {
+        List<GetHotSeller> hotSellers = new ArrayList<>();
+        Page<Long> sellers;
+        if (member != null) { // 로그인 했으면 숨김 리소스 제외
+            sellers = transactionRepository.getHotSellersWithoutHide(member,
+                    LocalDateTime.now().minusDays(7), PageRequest.of(0, 4));
+        } else {
+            sellers = transactionRepository.getHotSellers(
+                    LocalDateTime.now().minusDays(7), PageRequest.of(0, 4));
+        }
+        if (sellers != null) {
+            for (Long sellerId : sellers) {
+                Member seller = memberRepository.findByMemberIdWithDeleted(sellerId)
+                        .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
+                hotSellers.add(makeHotSellerForm(member, seller));
+            }
+        }
+        return hotSellers;
+    }
+
+    private List<GetRecentNft> getRecentNfts(Member member) {
+        List<GetRecentNft> recentNfts = new ArrayList<>();
+        Page<Nft> nfts;
+        if (member != null) { // 로그인 했으면 숨김 리소스 제외
+            nfts = nftRepository.getRecentNftsWithoutHide(member, PageRequest.of(0, 3));
+        } else {
+            nfts = nftRepository.getRecentNfts(PageRequest.of(0, 3));
+        }
+        nfts.forEach(nft -> recentNfts.add(makeGetRecentNftForm(member, nft)));
+        return recentNfts;
+    }
+
+    private List<GetHotMember> getHotMembers(Member member) {
+        List<GetHotMember> hotMembers = new ArrayList<>();
+        Page<Long> members;
+        if (member != null) { // 로그인 했으면 숨김 리소스 제외
+            members = transactionRepository.getHotMembersWithoutHide(member, LocalDateTime.now().minusDays(30),
+                    PageRequest.of(0, 3));
+        } else {
+            members = transactionRepository.getHotMembers(LocalDateTime.now().minusDays(30),
+                    PageRequest.of(0, 3));
+        }
+        if (members != null) {
+            for (Long memberId : members) {
+                Member hotMember = memberRepository.findByMemberIdWithDeleted(memberId)
+                        .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
+                hotMembers.add(makeGetHotMemberForm(member, hotMember));
+            }
+        }
+        return hotMembers;
+    }
+    /**
+     * Nft Entity를 넘겨 받아 GetHotItem DTO 형태로 만드는 함수
+     */
+    private GetHotItem makeHotItemForm(Nft nft) {
+        return new GetHotItem(nft.getNftId(), nft.getImgUrl(), nft.getTitle(), nft.getPrice(),
+                likeCountToString(likeRepository.getLikeCountsByNftId(nft).orElse(0L)));
+    }
+
+    /**
+     * Member Entity를 넘겨 받아 GetHotSeller DTO 형태로 만드는 함수
+     */
+    private GetHotSeller makeHotSellerForm(Member member, Member owner) {
+        List<String> nftImgUrls;
+        String nftImgUrl = "";
+        if (member != null) {
+            nftImgUrls = nftRepository.getRecentNftImgUrlWithoutHide(member, owner
+                    , PageRequest.of(0, 1)).orElse(null);
+        } else {
+            nftImgUrls = nftRepository.getRecentNftImgUrl(owner,
+                    PageRequest.of(0, 1)).orElse(null);
+        }
+        if (nftImgUrls != null) { // getRecentNftImgUrl 을 페이징으로 바꾸며 추가한 코드
+            nftImgUrl = nftImgUrls.get(0);
+        }
+        return new GetHotSeller(owner.getMemberId(), owner.getNickname(),
+                owner.getProfileUrl(), nftImgUrl);
+
+    }
+
+    /**
+     * Nft Entity를 넘겨 받아 GetRecentNft DTO 형태로 만드는 함수
+     */
+    private GetRecentNft makeGetRecentNftForm(Member member, Nft nft) {
+        boolean liked = false;
+        if (member != null) {
+            liked = getLikeUseCase.checkIsLiked(member, nft);
+        }
+        return new GetRecentNft(nft.getNftId(), nft.getTitle(), nft.getMember().getNickname(),
+                nft.getImgUrl(), nft.getPrice(), liked);
+    }
+
+    /**
+     * Member Entity를 넘겨 받아 GetHotMember DTO 형태로 만드는 함수
+     */
+    private GetHotMember makeGetHotMemberForm(Member member, Member target) {
+        boolean followed = false;
+        boolean isMe = false;
+        if (member != null) {
+            followed = getFollowUseCase.checkIsFollowed(member, target);
+            isMe = checkIsMe(member.getMemberId(), target.getMemberId());
+        }
+        return new GetHotMember(target.getMemberId(), target.getNickname(), target.getProfileUrl(),
+                nftRepository.countByMemberWithDeleted(target).orElse(0L), followed, isMe);
+    }
+
+    /**
+     * Member Entity를 넘겨 받아 MoreHoMember DTO 형태로 만드는 함수
+     */
+    private MoreHotMember makeMoreHotMembersForm(Member member, Member target, int limit) {
+        List<String> nftImgUrls;
+        if (member != null) {
+            nftImgUrls = nftRepository.getRecentNftImgUrlWithoutHide(member, target,
+                    PageRequest.of(0, limit)).orElse(null);
+        } else {
+            nftImgUrls = nftRepository.getRecentNftImgUrl(target,
+                    PageRequest.of(0, limit)).orElse(null);
+        }
+        return new MoreHotMember(makeGetHotMemberForm(member, target), nftImgUrls);
+    }
+
+    /**
+     * Page 를 넘겨 받아 MoreHotSeller List를 만드는 함수
+     * PageResponseDto로 반환
+     */
+    private PageResponseDto<List<MoreHotMember>> makeMoreHotMembersListForm(Member member, Page<Long> hotSellers, int limit) {
+        List<MoreHotMember> res = new ArrayList<>();
+        hotSellers.forEach(sellerId -> res.add(makeMoreHotMembersForm(member,
+                memberRepository.findByMemberIdWithDeleted(sellerId)
+                        .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER)), limit)));
+        return new PageResponseDto<>(
+                hotSellers.getNumber(), hotSellers.getSize(), hotSellers.hasNext(), res);
+    }
+
+    /**
+     * Page 를 넘겨 받아 GetRecentNft List를 만드는 함수
+     * PageResponseDto로 반환
+     */
+    private PageResponseDto<List<GetRecentNft>> makeMoreRecentNftsListForm(Member member, Page<Nft> nfts) {
+        List<GetRecentNft> res = new ArrayList<>();
+        nfts.forEach(nft -> res.add(makeGetRecentNftForm(member, nft)));
+        return new PageResponseDto<>(
+                nfts.getNumber(), nfts.getSize(), nfts.hasNext(), res);
+    }
+
+    private boolean checkIsMe(Long memberId, Long ownerId) {
+        return Objects.equals(memberId, ownerId);
+    }
+
+    private String likeCountToString(long likeCount) {
+        if (likeCount >= 1000) {
+            return likeCount / 1000 + "K";
+        } else return Long.toString(likeCount);
+    }
 }

--- a/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
+++ b/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
@@ -57,7 +57,7 @@ public class GetMarketService implements GetMarketUseCase {
     }
 
     /**
-     *  Nft Entity를 넘겨 받아 GetHotItem DTO 형태로 만드는 함수
+     * Nft Entity를 넘겨 받아 GetHotItem DTO 형태로 만드는 함수
      */
     public GetHotItem makeHotItemForm(Nft nft) {
         return new GetHotItem(nft.getNftId(), nft.getImgUrl(), nft.getTitle(), nft.getPrice(),
@@ -65,7 +65,7 @@ public class GetMarketService implements GetMarketUseCase {
     }
 
     /**
-     *  Member Entity를 넘겨 받아 GetHotSeller DTO 형태로 만드는 함수
+     * Member Entity를 넘겨 받아 GetHotSeller DTO 형태로 만드는 함수
      */
     public GetHotSeller makeHotSellerForm(Member member, Member owner) {
         List<String> nftImgUrls;
@@ -86,7 +86,7 @@ public class GetMarketService implements GetMarketUseCase {
     }
 
     /**
-     *  Nft Entity를 넘겨 받아 GetRecentNft DTO 형태로 만드는 함수
+     * Nft Entity를 넘겨 받아 GetRecentNft DTO 형태로 만드는 함수
      */
     public GetRecentNft makeGetRecentNftForm(Member member, Nft nft) {
         boolean liked = false;
@@ -98,41 +98,41 @@ public class GetMarketService implements GetMarketUseCase {
     }
 
     /**
-     *  Member Entity를 넘겨 받아 GetHotMember DTO 형태로 만드는 함수
+     * Member Entity를 넘겨 받아 GetHotMember DTO 형태로 만드는 함수
      */
-    public GetHotMember makeGetHotMemberForm(Member member, Member hotMember) {
+    public GetHotMember makeGetHotMemberForm(Member member, Member target) {
         boolean followed = false;
         boolean isMe = false;
         if (member != null) {
-            followed = getFollowUseCase.checkIsFollowed(member, hotMember);
-            isMe = checkIsMe(member.getMemberId(), hotMember.getMemberId());
+            followed = getFollowUseCase.checkIsFollowed(member, target);
+            isMe = checkIsMe(member.getMemberId(), target.getMemberId());
         }
-        return new GetHotMember(hotMember.getMemberId(), hotMember.getNickname(), hotMember.getProfileUrl(),
-                nftRepository.countByMemberWithDeleted(hotMember).orElse(0L), followed, isMe);
+        return new GetHotMember(target.getMemberId(), target.getNickname(), target.getProfileUrl(),
+                nftRepository.countByMemberWithDeleted(target).orElse(0L), followed, isMe);
     }
 
     /**
-     *  Member Entity를 넘겨 받아 MoreHotSeller DTO 형태로 만드는 함수
+     * Member Entity를 넘겨 받아 MoreHoMember DTO 형태로 만드는 함수
      */
-    public MoreHotSeller makeMoreHotSellersForm(Member member, Member seller, int limit) {
+    public MoreHotMember makeMoreHotMembersForm(Member member, Member target, int limit) {
         List<String> nftImgUrls;
         if (member != null) {
-            nftImgUrls = nftRepository.getRecentNftImgUrlWithoutHide(member, seller,
+            nftImgUrls = nftRepository.getRecentNftImgUrlWithoutHide(member, target,
                     PageRequest.of(0, limit)).orElse(null);
         } else {
-            nftImgUrls = nftRepository.getRecentNftImgUrl(seller,
+            nftImgUrls = nftRepository.getRecentNftImgUrl(target,
                     PageRequest.of(0, limit)).orElse(null);
         }
-        return new MoreHotSeller(makeGetHotMemberForm(member, seller), nftImgUrls);
+        return new MoreHotMember(makeGetHotMemberForm(member, target), nftImgUrls);
     }
 
     /**
-     *  Page 를 넘겨 받아 MoreHotSeller List를 만드는 함수
-     *  PageResponseDto로 반환
+     * Page 를 넘겨 받아 MoreHotSeller List를 만드는 함수
+     * PageResponseDto로 반환
      */
-    public PageResponseDto<List<MoreHotSeller>> makeMoreHotSellersListForm(Member member, Page<Long> hotSellers, int limit) {
-        List<MoreHotSeller> res = new ArrayList<>();
-        hotSellers.forEach(sellerId -> res.add(makeMoreHotSellersForm(member,
+    public PageResponseDto<List<MoreHotMember>> makeMoreHotMembersListForm(Member member, Page<Long> hotSellers, int limit) {
+        List<MoreHotMember> res = new ArrayList<>();
+        hotSellers.forEach(sellerId -> res.add(makeMoreHotMembersForm(member,
                 memberRepository.findByMemberIdWithDeleted(sellerId)
                         .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER)), limit)));
         return new PageResponseDto<>(
@@ -140,8 +140,8 @@ public class GetMarketService implements GetMarketUseCase {
     }
 
     /**
-     *  Page 를 넘겨 받아 GetRecentNft List를 만드는 함수
-     *  PageResponseDto로 반환
+     * Page 를 넘겨 받아 GetRecentNft List를 만드는 함수
+     * PageResponseDto로 반환
      */
     public PageResponseDto<List<GetRecentNft>> makeMoreRecentNftsListForm(Member member, Page<Nft> nfts) {
         List<GetRecentNft> res = new ArrayList<>();
@@ -228,12 +228,12 @@ public class GetMarketService implements GetMarketUseCase {
     }
 
     /**
-     *  핫 셀러(Hot Sellers) 더보기
-     *  controller 에서 넘겨 받은대로 paging 처리하여 가져오기
-     *  limit = 해당 유저가 민팅한 nftUrl을 몇개 보여줄건지
+     * 핫 셀러(Hot Sellers) 더보기
+     * controller 에서 넘겨 받은대로 paging 처리하여 가져오기
+     * limit = 해당 유저가 민팅한 nftUrl을 몇개 보여줄건지
      */
     @Override
-    public PageResponseDto<List<MoreHotSeller>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto) {
+    public PageResponseDto<List<MoreHotMember>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto) {
         Page<Long> sellers;
         if (member != null) { // 로그인 했으면 숨김 리소스 제외
             sellers = transactionRepository.getHotSellersWithoutHide(member,
@@ -242,16 +242,16 @@ public class GetMarketService implements GetMarketUseCase {
             sellers = transactionRepository.getHotSellers(
                     LocalDateTime.now().minusDays(7), pageReq(pageRequestDto));
         }
-        return makeMoreHotSellersListForm(member, sellers, 3);
+        return makeMoreHotMembersListForm(member, sellers, 3);
     }
 
     /**
-     *  활발한 활동(Hot Members) 더보기
-     *  controller 에서 넘겨 받은대로 paging 처리하여 가져오기
-     *  limit = 해당 유저가 민팅한 nftUrl을 몇개 보여줄건지
+     * 활발한 활동(Hot Members) 더보기
+     * controller 에서 넘겨 받은대로 paging 처리하여 가져오기
+     * limit = 해당 유저가 민팅한 nftUrl을 몇개 보여줄건지
      */
     @Override
-    public PageResponseDto<List<MoreHotSeller>> getMoreHotMembers(Member member, PageRequestDto pageRequestDto) {
+    public PageResponseDto<List<MoreHotMember>> getMoreHotMembers(Member member, PageRequestDto pageRequestDto) {
         Page<Long> members;
         if (member != null) { // 로그인 했으면 숨김 리소스 제외
             members = transactionRepository.getHotMembersWithoutHide(member, LocalDateTime.now().minusDays(30),
@@ -260,12 +260,12 @@ public class GetMarketService implements GetMarketUseCase {
             members = transactionRepository.getHotMembers(LocalDateTime.now().minusDays(30),
                     pageReq(pageRequestDto));
         }
-        return makeMoreHotSellersListForm(member, members, 10);
+        return makeMoreHotMembersListForm(member, members, 10);
     }
 
     /**
-     *  최신 NFT(Recent Nfts) 더보기
-     *  controller 에서 넘겨 받은대로 paging 처리하여 가져오기
+     * 최신 NFT(Recent Nfts) 더보기
+     * controller 에서 넘겨 받은대로 paging 처리하여 가져오기
      */
     @Override
     public PageResponseDto<List<GetRecentNft>> getMoreRecentNfts(Member member, PageRequestDto pageRequestDto) {

--- a/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
+++ b/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
@@ -1,32 +1,29 @@
 package com.service.dida.domain.market.service;
 
 import com.service.dida.domain.follow.usecase.GetFollowUseCase;
-import com.service.dida.domain.like.usecase.GetLikeUseCase;
-import com.service.dida.domain.market.dto.MarketResponseDto.GetHotItem;
-import com.service.dida.domain.market.dto.MarketResponseDto.GetHotSeller;
-import com.service.dida.domain.market.dto.MarketResponseDto.GetRecentNft;
-import com.service.dida.domain.market.dto.MarketResponseDto.GetHotMember;
-import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSoldOut;
-
 import com.service.dida.domain.like.repository.LikeRepository;
+import com.service.dida.domain.like.usecase.GetLikeUseCase;
+import com.service.dida.domain.market.dto.MarketResponseDto.*;
 import com.service.dida.domain.market.usecase.GetMarketUseCase;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.member.repository.MemberRepository;
 import com.service.dida.domain.nft.Nft;
 import com.service.dida.domain.nft.repository.NftRepository;
 import com.service.dida.domain.transaction.repository.TransactionRepository;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
 import com.service.dida.global.config.exception.BaseException;
 import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +37,15 @@ public class GetMarketService implements GetMarketUseCase {
     private final GetLikeUseCase getLikeUseCase;
     private final GetFollowUseCase getFollowUseCase;
 
+    /**
+     * Market 조회에서 공통으로 사용 될 PageRequest 를 정의하는 함수
+     */
+    public PageRequest pageReq(PageRequestDto pageRequestDto) {
+        // pageRequest 는 원하는 page, 한 page 당 size, 최신 순서 정렬 이라는 요청을 담고 있다.
+        return PageRequest.of(pageRequestDto.getPage(), pageRequestDto.getPageSize()
+                , Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
     public String likeCountToString(long likeCount) {
         if (likeCount >= 1000) {
             return likeCount / 1000 + "K";
@@ -52,11 +58,17 @@ public class GetMarketService implements GetMarketUseCase {
     }
 
     public GetHotSeller makeHotSellerForm(Member member, Member owner) {
+        List<String> nftImgUrls;
         String nftImgUrl = "";
-        if(member != null) {
-            nftImgUrl = nftRepository.getRecentNftImgUrlWithoutHide(member, owner).orElse("");
+        if (member != null) {
+            nftImgUrls = nftRepository.getRecentNftImgUrlWithoutHide(member, owner
+                    , PageRequest.of(0, 1)).orElse(null);
         } else {
-            nftImgUrl = nftRepository.getRecentNftImgUrl(owner).orElse("");
+            nftImgUrls = nftRepository.getRecentNftImgUrl(owner,
+                    PageRequest.of(0, 1)).orElse(null);
+        }
+        if (nftImgUrls != null) { // getRecentNftImgUrl 을 페이징으로 바꾸며 추가한 코드
+            nftImgUrl = nftImgUrls.get(0);
         }
         return new GetHotSeller(owner.getMemberId(), owner.getNickname(),
                 owner.getProfileUrl(), nftImgUrl);
@@ -65,7 +77,7 @@ public class GetMarketService implements GetMarketUseCase {
 
     public GetRecentNft makeGetRecentNftForm(Member member, Nft nft) {
         boolean liked = false;
-        if(member != null) {
+        if (member != null) {
             liked = getLikeUseCase.checkIsLiked(member, nft);
         }
         return new GetRecentNft(nft.getNftId(), nft.getTitle(), nft.getMember().getNickname(),
@@ -105,13 +117,13 @@ public class GetMarketService implements GetMarketUseCase {
 
     public List<GetHotSeller> getHotSellers(Member member) {
         List<GetHotSeller> hotSellers = new ArrayList<>();
-        List<Long> sellers;
+        Page<Long> sellers;
         if (member != null) { // 로그인 했으면 숨김 리소스 제외
             sellers = transactionRepository.getHotSellersWithoutHide(member,
-                    LocalDateTime.now().minusDays(7)).orElse(null);
+                    LocalDateTime.now().minusDays(7), PageRequest.of(0, 4));
         } else {
             sellers = transactionRepository.getHotSellers(
-                    LocalDateTime.now().minusDays(7)).orElse(null);
+                    LocalDateTime.now().minusDays(7), PageRequest.of(0, 4));
         }
         if (sellers != null) {
             for (Long sellerId : sellers) {
@@ -123,13 +135,13 @@ public class GetMarketService implements GetMarketUseCase {
         return hotSellers;
     }
 
-    public List<GetRecentNft> getRecentNfts(Member member, PageRequest pageRequest) {
+    public List<GetRecentNft> getRecentNfts(Member member) {
         List<GetRecentNft> recentNfts = new ArrayList<>();
         Page<Nft> nfts;
         if (member != null) { // 로그인 했으면 숨김 리소스 제외
-            nfts = nftRepository.getRecentNftsWithoutHide(member, pageRequest);
+            nfts = nftRepository.getRecentNftsWithoutHide(member, PageRequest.of(0, 3));
         } else {
-            nfts = nftRepository.getRecentNfts(pageRequest);
+            nfts = nftRepository.getRecentNfts(PageRequest.of(0, 3));
         }
         nfts.forEach(nft -> recentNfts.add(makeGetRecentNftForm(member, nft)));
         return recentNfts;
@@ -158,9 +170,43 @@ public class GetMarketService implements GetMarketUseCase {
     public GetMainPageWithoutSoldOut getMainPage(Member member) {
         List<GetHotItem> hotItems = getHotItems(member);
         List<GetHotSeller> hotSellers = getHotSellers(member);
-        List<GetRecentNft> recentNfts = getRecentNfts(member, PageRequest.of(0, 4));
+        List<GetRecentNft> recentNfts = getRecentNfts(member);
         List<GetHotMember> hotMembers = getHotMembers(member);
         return new GetMainPageWithoutSoldOut(hotItems, hotSellers, recentNfts, hotMembers);
+    }
+
+    public MoreHotSellers makeMoreHotSellersForm(Member member, Member seller) {
+        List<String> nftImgUrls;
+        if (member != null) {
+            nftImgUrls = nftRepository.getRecentNftImgUrlWithoutHide(member, seller,
+                    PageRequest.of(0, 3)).orElse(null);
+        } else {
+            nftImgUrls = nftRepository.getRecentNftImgUrl(seller,
+                    PageRequest.of(0, 3)).orElse(null);
+        }
+        return new MoreHotSellers(makeGetHotMemberForm(member, seller), nftImgUrls);
+    }
+
+    public PageResponseDto<List<MoreHotSellers>> makeMoreHotSellersListForm(Member member, Page<Long> hotSellers) {
+        List<MoreHotSellers> res = new ArrayList<>();
+        hotSellers.forEach(sellerId -> res.add(makeMoreHotSellersForm(member,
+                memberRepository.findByMemberIdWithDeleted(sellerId)
+                        .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER)))));
+        return new PageResponseDto<>(
+                hotSellers.getNumber(), hotSellers.getSize(), hotSellers.hasNext(), res);
+    }
+
+    @Override
+    public PageResponseDto<List<MoreHotSellers>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto) {
+        Page<Long> sellers;
+        if (member != null) { // 로그인 했으면 숨김 리소스 제외
+            sellers = transactionRepository.getHotSellersWithoutHide(member,
+                    LocalDateTime.now().minusDays(7), pageReq(pageRequestDto));
+        } else {
+            sellers = transactionRepository.getHotSellers(
+                    LocalDateTime.now().minusDays(7), pageReq(pageRequestDto));
+        }
+        return makeMoreHotSellersListForm(member, sellers);
     }
 
 }

--- a/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
+++ b/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
@@ -196,6 +196,13 @@ public class GetMarketService implements GetMarketUseCase {
                 hotSellers.getNumber(), hotSellers.getSize(), hotSellers.hasNext(), res);
     }
 
+    public PageResponseDto<List<GetRecentNft>> makeMoreRecentNftsListForm(Member member, Page<Nft> nfts) {
+        List<GetRecentNft> res = new ArrayList<>();
+        nfts.forEach(nft -> res.add(makeGetRecentNftForm(member, nft)));
+        return new PageResponseDto<>(
+                nfts.getNumber(), nfts.getSize(), nfts.hasNext(), res);
+    }
+
     @Override
     public PageResponseDto<List<MoreHotSeller>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto) {
         Page<Long> sellers;
@@ -207,6 +214,17 @@ public class GetMarketService implements GetMarketUseCase {
                     LocalDateTime.now().minusDays(7), pageReq(pageRequestDto));
         }
         return makeMoreHotSellersListForm(member, sellers);
+    }
+
+    @Override
+    public PageResponseDto<List<GetRecentNft>> getMoreRecentNfts(Member member, PageRequestDto pageRequestDto) {
+        Page<Nft> nfts;
+        if (member != null) { // 로그인 했으면 숨김 리소스 제외
+            nfts = nftRepository.getRecentNftsWithoutHide(member, pageReq(pageRequestDto));
+        } else {
+            nfts = nftRepository.getRecentNfts(pageReq(pageRequestDto));
+        }
+        return makeMoreRecentNftsListForm(member, nfts);
     }
 
 }

--- a/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
+++ b/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface GetMarketUseCase {
 
     GetMainPageWithoutSoldOut getMainPage(Member member);
-    PageResponseDto<List<MarketResponseDto.MoreHotSellers>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
+    PageResponseDto<List<MarketResponseDto.MoreHotSeller>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
+++ b/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
@@ -12,4 +12,5 @@ public interface GetMarketUseCase {
 
     GetMainPageWithoutSoldOut getMainPage(Member member);
     PageResponseDto<List<MarketResponseDto.MoreHotSeller>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
+    PageResponseDto<List<MarketResponseDto.GetRecentNft>> getMoreRecentNfts(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
+++ b/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface GetMarketUseCase {
 
     GetMainPageWithoutSoldOut getMainPage(Member member);
-    PageResponseDto<List<MarketResponseDto.MoreHotSeller>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
+    PageResponseDto<List<MarketResponseDto.MoreHotMember>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
     PageResponseDto<List<MarketResponseDto.GetRecentNft>> getMoreRecentNfts(Member member, PageRequestDto pageRequestDto);
-    PageResponseDto<List<MarketResponseDto.MoreHotSeller>> getMoreHotMembers(Member member, PageRequestDto pageRequestDto);
+    PageResponseDto<List<MarketResponseDto.MoreHotMember>> getMoreHotMembers(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
+++ b/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
@@ -1,9 +1,15 @@
 package com.service.dida.domain.market.usecase;
 
+import com.service.dida.domain.market.dto.MarketResponseDto;
 import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSoldOut;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+
+import java.util.List;
 
 public interface GetMarketUseCase {
 
     GetMainPageWithoutSoldOut getMainPage(Member member);
+    PageResponseDto<List<MarketResponseDto.MoreHotSellers>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
+++ b/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
@@ -13,4 +13,5 @@ public interface GetMarketUseCase {
     GetMainPageWithoutSoldOut getMainPage(Member member);
     PageResponseDto<List<MarketResponseDto.MoreHotSeller>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
     PageResponseDto<List<MarketResponseDto.GetRecentNft>> getMoreRecentNfts(Member member, PageRequestDto pageRequestDto);
+    PageResponseDto<List<MarketResponseDto.MoreHotSeller>> getMoreHotMembers(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
+++ b/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
@@ -2,13 +2,14 @@ package com.service.dida.domain.nft.repository;
 
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
-import java.util.Optional;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface NftRepository extends JpaRepository<Nft, Long> {
@@ -26,11 +27,11 @@ public interface NftRepository extends JpaRepository<Nft, Long> {
 
     @Query(value = "SELECT n.imgUrl FROM Nft n " +
             "WHERE n NOT IN (SELECT nh.nft FROM NftHide nh WHERE nh.member=:member) " +
-            "AND n.member=:owner ORDER BY n.createdAt DESC LIMIT 1")
-    Optional<String> getRecentNftImgUrlWithoutHide(Member member, Member owner);
+            "AND n.member=:owner ORDER BY n.createdAt DESC")
+    Optional<List<String>> getRecentNftImgUrlWithoutHide(Member member, Member owner, PageRequest pageRequest);
 
-    @Query(value = "SELECT n.imgUrl FROM Nft n WHERE n.member=:owner ORDER BY n.createdAt DESC LIMIT 1")
-    Optional<String> getRecentNftImgUrl(Member owner);
+    @Query(value = "SELECT n.imgUrl FROM Nft n WHERE n.member=:owner ORDER BY n.createdAt DESC")
+    Optional<List<String>> getRecentNftImgUrl(Member owner, PageRequest pageRequest);
 
     @Query(value = "SELECT n FROM Nft n " +
             "WHERE (n) NOT IN (SELECT nh.nft FROM NftHide nh WHERE nh.member=:member) " +

--- a/src/main/java/com/service/dida/domain/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/service/dida/domain/transaction/repository/TransactionRepository.java
@@ -26,12 +26,12 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
 
     @Query(value = "SELECT t.sellerId FROM Transaction t WHERE t.type='DEAL' " +
             "AND (t.sellerId) NOT IN (SELECT mh.hideMember.memberId FROM MemberHide mh WHERE mh.member=:member) " +
-            "AND t.createdAt >:date GROUP BY t.sellerId ORDER BY COUNT(t.sellerId) DESC LIMIT 4")
-    Optional<List<Long>> getHotSellersWithoutHide(Member member, LocalDateTime date);
+            "AND t.createdAt >:date GROUP BY t.sellerId ORDER BY COUNT(t.sellerId) DESC")
+    Page<Long> getHotSellersWithoutHide(Member member, LocalDateTime date, PageRequest pageRequest);
 
     @Query(value = "SELECT t.sellerId FROM Transaction t WHERE t.type='DEAL' " +
             "AND t.createdAt >:date GROUP BY t.sellerId ORDER BY COUNT(t.sellerId) DESC LIMIT 4")
-    Optional<List<Long>> getHotSellers(LocalDateTime date);
+    Page<Long> getHotSellers(LocalDateTime date, PageRequest pageRequest);
 
     @Query(value = "SELECT t.buyerId FROM Transaction t WHERE t.type='MINTING' " +
             "AND t.createdAt >:date AND COUNT(t.buyerId) >= 10 GROUP BY t.buyerId ORDER BY COUNT(t.buyerId) DESC LIMIT 3")
@@ -41,4 +41,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
             "AND (t.buyerId) NOT IN (SELECT mh.hideMember.memberId FROM MemberHide mh WHERE mh.member=:member) " +
             "AND t.createdAt >:date AND COUNT(t.buyerId) >= 10 GROUP BY t.buyerId ORDER BY COUNT(t.buyerId) DESC LIMIT 3")
     Optional<List<Long>> getHotMembersWithoutHide(Member member, LocalDateTime date);
+
+    @Query(value = "SELECT t.sellerId")
+    Optional<List<Long>> getMoreHotSellersWithoutHide(Member member, LocalDateTime date);
 }

--- a/src/main/java/com/service/dida/domain/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/service/dida/domain/transaction/repository/TransactionRepository.java
@@ -8,8 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
     @Query(value = "select t from Transaction t where t.buyerId = :memberId and (t.type = 'SWAP1' or t.type = 'SWAP2' or t.type = 'SEND_OUT_KLAY')")
@@ -34,14 +32,12 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
     Page<Long> getHotSellers(LocalDateTime date, PageRequest pageRequest);
 
     @Query(value = "SELECT t.buyerId FROM Transaction t WHERE t.type='MINTING' " +
-            "AND t.createdAt >:date AND COUNT(t.buyerId) >= 10 GROUP BY t.buyerId ORDER BY COUNT(t.buyerId) DESC LIMIT 3")
-    Optional<List<Long>> getHotMembers(LocalDateTime date);
+            "AND t.createdAt >:date AND COUNT(t.buyerId) >= 10 GROUP BY t.buyerId ORDER BY COUNT(t.buyerId) DESC")
+    Page<Long> getHotMembers(LocalDateTime date, PageRequest pageRequest);
 
     @Query(value = "SELECT t.buyerId FROM Transaction t WHERE t.type='MINTING' " +
             "AND (t.buyerId) NOT IN (SELECT mh.hideMember.memberId FROM MemberHide mh WHERE mh.member=:member) " +
-            "AND t.createdAt >:date AND COUNT(t.buyerId) >= 10 GROUP BY t.buyerId ORDER BY COUNT(t.buyerId) DESC LIMIT 3")
-    Optional<List<Long>> getHotMembersWithoutHide(Member member, LocalDateTime date);
+            "AND t.createdAt >:date AND COUNT(t.buyerId) >= 10 GROUP BY t.buyerId ORDER BY COUNT(t.buyerId) DESC")
+    Page<Long> getHotMembersWithoutHide(Member member, LocalDateTime date, PageRequest pageRequest);
 
-    @Query(value = "SELECT t.sellerId")
-    Optional<List<Long>> getMoreHotSellersWithoutHide(Member member, LocalDateTime date);
 }


### PR DESCRIPTION
### 요약

- HotSeller 더보기 API
- 최신 NFT(Recent Nft) 더보기 API
- 활발한 활동(Hot Member) 더보기 API
### 상세 내용

- 페이징 처리 완료
- 로그인 여부 확인하여 숨기기/좋아요/내게시글 여부 고려 
- 메인화면 API에서 사용했던 쿼리들 페이징으로 바꾼 후 재사용

### 질문 및 이외 사항

- HotItem은 더보기가 없더라고요!
- HotSeller 더보기랑 HotMember 더보기 둘 다, 기존에 Main 화면에서 사용하던 쿼리 함수를 페이징으로 바꾼 후 재사용 했습니다! 쿼리 함수가 seller의 id만 가져오는 거라 재사용 할 수 있겠더라구용!! 
- MoreHotMember DTO는 아래와 같은데 HotSeller 더보기랑 HotMember 더보기의 형태가 같아서 공통으로 사용했습니다! 코드 확인하실 때 착오 없으시라고 알려드립니다!
```
    @Getter
    @AllArgsConstructor
    public static class MoreHotMember {
        private GetHotMember memberInfo;
        private List<String> nftImgUrl;
    }
```
### 이슈 번호

- close #44, close #45, close #46 