### PR TITLE
버전 확인하기 API

### DIFF
--- a/src/main/java/com/service/dida/global/common/version/Version.java
+++ b/src/main/java/com/service/dida/global/common/version/Version.java
@@ -1,0 +1,23 @@
+package com.service.dida.global.common.version;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "version")
+public class Version {
+    @Id
+    @Column(name = "version_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long versionId;
+    @Column(name = "app_version")
+    private Long appVersion;
+
+    public void upVersion() {
+        this.appVersion = this.appVersion + 1;
+    }
+}

--- a/src/main/java/com/service/dida/global/common/version/Version.java
+++ b/src/main/java/com/service/dida/global/common/version/Version.java
@@ -14,10 +14,21 @@ public class Version {
     @Column(name = "version_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long versionId;
-    @Column(name = "app_version")
-    private Long appVersion;
 
-    public void upVersion() {
-        this.appVersion = this.appVersion + 1;
+    @Column(name = "major", nullable = false)
+    private Long major;
+    @Column(name = "minor", nullable = false)
+    private Long minor;
+    @Column(name = "patch", nullable = false)
+    private Long patch;
+
+    public void upMajor() {
+        this.major = this.major + 1;
+    }
+    public void upMinor() {
+        this.minor = this.minor + 1;
+    }
+    public void upPatch() {
+        this.patch = this.patch + 1;
     }
 }

--- a/src/main/java/com/service/dida/global/common/version/VersionController.java
+++ b/src/main/java/com/service/dida/global/common/version/VersionController.java
@@ -1,0 +1,24 @@
+package com.service.dida.global.common.version;
+
+import com.service.dida.global.common.version.dto.VersionResponseDto.AppVersion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class VersionController {
+
+    private final VersionUseCase versionUseCase;
+
+    /**
+     * 앱 최신 버전 확인 api
+     * [GET] /app/version
+     */
+    @GetMapping("/app/version")
+    public ResponseEntity<AppVersion> getAppVersion() {
+        return new ResponseEntity<>(versionUseCase.getAppVersion(0L), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/global/common/version/VersionRepository.java
+++ b/src/main/java/com/service/dida/global/common/version/VersionRepository.java
@@ -1,10 +1,10 @@
 package com.service.dida.global.common.version;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 
 public interface VersionRepository extends JpaRepository<Version, Long> {
 
-    Optional<Long> findAppVersionByVersionId(Long versionId);
+    @Query(value = "SELECT v FROM version v WHERE v.versionId=:versionId")
+    Version getVersionByVersionId(Long versionId);
 }

--- a/src/main/java/com/service/dida/global/common/version/VersionRepository.java
+++ b/src/main/java/com/service/dida/global/common/version/VersionRepository.java
@@ -1,0 +1,10 @@
+package com.service.dida.global.common.version;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface VersionRepository extends JpaRepository<Version, Long> {
+
+    Optional<Long> findAppVersionByVersionId(Long versionId);
+}

--- a/src/main/java/com/service/dida/global/common/version/VersionService.java
+++ b/src/main/java/com/service/dida/global/common/version/VersionService.java
@@ -1,0 +1,17 @@
+package com.service.dida.global.common.version;
+
+import com.service.dida.global.common.version.dto.VersionResponseDto.AppVersion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VersionService implements VersionUseCase{
+
+    private final VersionRepository versionRepository;
+
+    public AppVersion getAppVersion(Long versionId) {
+        return new AppVersion(versionRepository.findAppVersionByVersionId(versionId).orElse(0L));
+    }
+
+}

--- a/src/main/java/com/service/dida/global/common/version/VersionService.java
+++ b/src/main/java/com/service/dida/global/common/version/VersionService.java
@@ -10,8 +10,14 @@ public class VersionService implements VersionUseCase{
 
     private final VersionRepository versionRepository;
 
+    @Override
     public AppVersion getAppVersion(Long versionId) {
-        return new AppVersion(versionRepository.findAppVersionByVersionId(versionId).orElse(0L));
+        Version version = versionRepository.getVersionByVersionId(versionId);
+        return new AppVersion(versionToString(version));
+    }
+
+    private String versionToString(Version version) {
+        return version.getMajor() + "." + version.getMinor() + "." + version.getPatch();
     }
 
 }

--- a/src/main/java/com/service/dida/global/common/version/VersionUseCase.java
+++ b/src/main/java/com/service/dida/global/common/version/VersionUseCase.java
@@ -1,0 +1,7 @@
+package com.service.dida.global.common.version;
+
+import com.service.dida.global.common.version.dto.VersionResponseDto;
+
+public interface VersionUseCase {
+    VersionResponseDto.AppVersion getAppVersion(Long versionId);
+}

--- a/src/main/java/com/service/dida/global/common/version/dto/VersionResponseDto.java
+++ b/src/main/java/com/service/dida/global/common/version/dto/VersionResponseDto.java
@@ -1,0 +1,17 @@
+package com.service.dida.global.common.version.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class VersionResponseDto {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AppVersion {
+        private Long version;
+    }
+}

--- a/src/main/java/com/service/dida/global/common/version/dto/VersionResponseDto.java
+++ b/src/main/java/com/service/dida/global/common/version/dto/VersionResponseDto.java
@@ -12,6 +12,6 @@ public class VersionResponseDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class AppVersion {
-        private Long version;
+        private String version;
     }
 }


### PR DESCRIPTION
### 요약

- 버전 확인하기 API 구현
### 상세 내용

- Version Entity는 Long Type의 Major, Minor, Patch로 이루어집니다. `{major}.{minor}.{patch}`
- Major: 기존 버전과 호환 되지 않는 대규모 업데이트를 의미한다고 합니다! 4.2.1의 버전은 그동안 4번의 대규모 업데이트를 진행했다는 것을 알 수 있습니다! 그리고 버전 up을 하는 경우 뒤 숫자들은 0으로 초기화 합니다!
- Minor: 기존 버전과 호환은 되지만 새로운 기능이 추가되는 경우 해당 숫자가 증가됩니다! 4.2.1의 버전에서는 총 두번의 새로운 기능이 추가 된 것입니다! 
- Patch: 보통 버그를 수정하거나 여러 오류들을 수정하고 배포할 때 해당 숫자가 증가한다고 합니다! 
- 그래서 해당 API 호출 시 버전이 `0.0.0`과 같은 String 형태로 내려옵니당!
### 질문 및 이외 사항

- 두 번째 커밋을 주로 봐주시면 될 거 같습니당!
- 배포 시 자동으로 버전이 바뀌게 해야하나여?0? 아니면 DB에 직접 접근해서 바꾸나여?0?
### 이슈 번호

- close #72 