### PR TITLE
SNS 부가 기능과 메인화면 sold out 관련 API 

### DIFF
--- a/src/main/java/com/service/dida/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/service/dida/domain/comment/repository/CommentRepository.java
@@ -2,11 +2,13 @@ package com.service.dida.domain.comment.repository;
 
 import com.service.dida.domain.comment.Comment;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.post.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -20,4 +22,18 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query(value = "SELECT c FROM Comment c WHERE c.deleted = false")
     Optional<Comment> findByCommentIdWithDeleted(Long postId);
+
+    @Query(value = "SELECT c.post FROM Comment c WHERE c.deleted = false " +
+            "AND c.post.member NOT IN (SELECT mh.hideMember FROM MemberHide mh WHERE mh.member=:member) " +
+            "AND c.post.nft.member NOT IN (SELECT mh.hideMember FROM MemberHide mh WHERE mh.member=:member) " +
+            "AND c.post.nft NOT IN (SELECT nh.nft FROM NftHide nh WHERE nh.member=:member) " +
+            "AND c.post NOT IN (SELECT ph.post FROM PostHide ph WHERE ph.member=:member) " +
+            "AND c.post.createdAt >:date GROUP BY (c.post) ORDER BY COUNT(c.commentId) DESC")
+    Page<Post> findPostsByCommentCount(Member member, LocalDateTime date, PageRequest pageRequest);
+
+    @Query(value = "SELECT c.post FROM Comment c WHERE c.deleted = false " +
+            "AND c.post.createdAt >:date GROUP BY (c.post) ORDER BY COUNT(c.commentId) DESC")
+    Page<Post> findPostsByCommentCountWithoutHide(LocalDateTime date, PageRequest pageRequest);
+
+    Integer countByPostAndDeletedFalse(Post post);
 }

--- a/src/main/java/com/service/dida/domain/like/controller/GetLikeController.java
+++ b/src/main/java/com/service/dida/domain/like/controller/GetLikeController.java
@@ -1,0 +1,34 @@
+package com.service.dida.domain.like.controller;
+
+import com.service.dida.domain.like.usecase.GetLikeUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.dto.NftResponseDto;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class GetLikeController {
+
+    private final GetLikeUseCase getLikeUseCase;
+
+    /**
+     * 내가 좋아요한 NFT 목록 보기 Api
+     */
+    @GetMapping("/common/nft/like")
+    public ResponseEntity<PageResponseDto<List<NftResponseDto.SnsNft>>> getMyLikeNftList(
+            @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto) {
+        return new ResponseEntity<>(
+                getLikeUseCase.getMyLikeNftList(member, pageRequestDto), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/service/dida/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/service/dida/domain/like/repository/LikeRepository.java
@@ -1,14 +1,15 @@
 package com.service.dida.domain.like.repository;
 
-import java.awt.print.Pageable;
-import java.util.List;
-import java.util.Optional;
-
 import com.service.dida.domain.like.Like;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
@@ -20,6 +21,9 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     @Query(value = "SELECT l.nft FROM Like l " +
             "WHERE l.status = true GROUP BY l.nft ORDER BY COUNT(l.nft) DESC LIMIT 6")
     Optional<List<Nft>> getHotItems();
+
+    @Query(value = "SELECT l.nft FROM Like l WHERE l.member = :member AND l.status = true")
+    Page<Nft> getNftsByMemberAndStatusTrue(Member member, PageRequest pageRequest);
 
     @Query(value = "SELECT COUNT(l) FROM Like l WHERE l.nft = :nft AND l.status = true")
     Optional<Long> getLikeCountsByNftId(Nft nft);

--- a/src/main/java/com/service/dida/domain/like/service/GetLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/GetLikeService.java
@@ -5,9 +5,18 @@ import com.service.dida.domain.like.repository.LikeRepository;
 import com.service.dida.domain.like.usecase.GetLikeUseCase;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
+import com.service.dida.domain.nft.dto.NftResponseDto.SnsNft;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,5 +37,17 @@ public class GetLikeService implements GetLikeUseCase {
         } else {
             return like.isStatus();
         }
+    }
+
+    @Override
+    public PageResponseDto<List<SnsNft>> getMyLikeNftList(Member member, PageRequestDto pageRequestDto) {
+        List<SnsNft> res = new ArrayList<>();
+        Page<Nft> nfts = likeRepository.getNftsByMemberAndStatusTrue(member,
+                PageRequest.of(pageRequestDto.getPage(), pageRequestDto.getPageSize()
+                , Sort.by(Sort.Direction.DESC, "updatedAt")));
+
+        nfts.forEach(nft -> res.add(new SnsNft(nft)));
+
+        return new PageResponseDto<>(nfts.getNumber(), nfts.getSize(), nfts.hasNext(), res);
     }
 }

--- a/src/main/java/com/service/dida/domain/like/usecase/GetLikeUseCase.java
+++ b/src/main/java/com/service/dida/domain/like/usecase/GetLikeUseCase.java
@@ -2,7 +2,14 @@ package com.service.dida.domain.like.usecase;
 
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
+import com.service.dida.domain.nft.dto.NftResponseDto;
+import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+
+import java.util.List;
 
 public interface GetLikeUseCase {
     boolean checkIsLiked(Member member, Nft nft);
+
+    PageResponseDto<List<NftResponseDto.SnsNft>> getMyLikeNftList(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
+++ b/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
@@ -5,6 +5,7 @@ import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSo
 import com.service.dida.domain.market.dto.MarketResponseDto.MoreHotMember;
 import com.service.dida.domain.market.usecase.GetMarketUseCase;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.dto.NftResponseDto;
 import com.service.dida.global.common.dto.PageRequestDto;
 import com.service.dida.global.common.dto.PageResponseDto;
 import com.service.dida.global.config.exception.BaseException;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -31,6 +33,17 @@ public class GetMarketController {
     public ResponseEntity<GetMainPageWithoutSoldOut> getMainPage(@CurrentMember Member member)
             throws BaseException {
         return new ResponseEntity<>(getMarketUseCase.getMainPage(member), HttpStatus.OK);
+    }
+
+    /**
+     * 메인 화면 Sold Out 가져오기
+     * [GET] /main/sold-out
+     */
+    @GetMapping("/main/sold-out")
+    public ResponseEntity<List<NftResponseDto.NftAndMemberInfo>> getMainPageSoldOut(
+            @CurrentMember Member member, @RequestParam ("range") int range)
+            throws BaseException {
+        return new ResponseEntity<>(getMarketUseCase.getMainPageSoldOut(member, range), HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
+++ b/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
@@ -1,11 +1,11 @@
 package com.service.dida.domain.market.controller;
 
-import com.service.dida.domain.market.dto.MarketResponseDto.GetRecentNft;
 import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSoldOut;
+import com.service.dida.domain.market.dto.MarketResponseDto.GetRecentNft;
 import com.service.dida.domain.market.dto.MarketResponseDto.MoreHotMember;
 import com.service.dida.domain.market.usecase.GetMarketUseCase;
 import com.service.dida.domain.member.entity.Member;
-import com.service.dida.domain.nft.dto.NftResponseDto;
+import com.service.dida.domain.nft.dto.NftResponseDto.NftAndMemberInfo;
 import com.service.dida.global.common.dto.PageRequestDto;
 import com.service.dida.global.common.dto.PageResponseDto;
 import com.service.dida.global.config.exception.BaseException;
@@ -40,10 +40,23 @@ public class GetMarketController {
      * [GET] /main/sold-out
      */
     @GetMapping("/main/sold-out")
-    public ResponseEntity<List<NftResponseDto.NftAndMemberInfo>> getMainPageSoldOut(
-            @CurrentMember Member member, @RequestParam ("range") int range)
+    public ResponseEntity<List<NftAndMemberInfo>> getMainPageSoldOut(
+            @CurrentMember Member member, @RequestParam("range") int range)
             throws BaseException {
-        return new ResponseEntity<>(getMarketUseCase.getMainPageSoldOut(member, range), HttpStatus.OK);
+        return new ResponseEntity<>(getMarketUseCase.getMainPageSoldOut(member, range, 0, 3), HttpStatus.OK);
+    }
+
+    /**
+     * Sold out 더보기
+     * [GET] /sold-out
+     */
+    @GetMapping("/sold-out")
+    public ResponseEntity<PageResponseDto<List<NftAndMemberInfo>>> getMoreSoldOuts(
+            @CurrentMember Member member, @RequestParam("range") int range,
+            @RequestBody PageRequestDto pageRequestDto)
+            throws BaseException {
+        return new ResponseEntity<>(getMarketUseCase.getMoreSoldOuts(member, range, pageRequestDto),
+                HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
+++ b/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
@@ -12,7 +12,8 @@ import java.util.List;
 public interface GetMarketUseCase {
 
     GetMainPageWithoutSoldOut getMainPage(Member member);
-    List<NftResponseDto.NftAndMemberInfo> getMainPageSoldOut(Member member, int range);
+    List<NftResponseDto.NftAndMemberInfo> getMainPageSoldOut(Member member, int range, int page, int limit);
+    PageResponseDto<List<NftResponseDto.NftAndMemberInfo>> getMoreSoldOuts(Member member, int range, PageRequestDto pageRequestDto);
     PageResponseDto<List<MarketResponseDto.MoreHotMember>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
     PageResponseDto<List<MarketResponseDto.GetRecentNft>> getMoreRecentNfts(Member member, PageRequestDto pageRequestDto);
     PageResponseDto<List<MarketResponseDto.MoreHotMember>> getMoreHotMembers(Member member, PageRequestDto pageRequestDto);

--- a/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
+++ b/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
@@ -3,6 +3,7 @@ package com.service.dida.domain.market.usecase;
 import com.service.dida.domain.market.dto.MarketResponseDto;
 import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSoldOut;
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.dto.NftResponseDto;
 import com.service.dida.global.common.dto.PageRequestDto;
 import com.service.dida.global.common.dto.PageResponseDto;
 
@@ -11,6 +12,7 @@ import java.util.List;
 public interface GetMarketUseCase {
 
     GetMainPageWithoutSoldOut getMainPage(Member member);
+    List<NftResponseDto.NftAndMemberInfo> getMainPageSoldOut(Member member, int range);
     PageResponseDto<List<MarketResponseDto.MoreHotMember>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
     PageResponseDto<List<MarketResponseDto.GetRecentNft>> getMoreRecentNfts(Member member, PageRequestDto pageRequestDto);
     PageResponseDto<List<MarketResponseDto.MoreHotMember>> getMoreHotMembers(Member member, PageRequestDto pageRequestDto);

--- a/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
+++ b/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.nft.controller;
 
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.dto.NftResponseDto.SnsNft;
 import com.service.dida.domain.nft.dto.NftResponseDto.NftDetailInfo;
 import com.service.dida.domain.nft.dto.NftResponseDto.ProfileNft;
 import com.service.dida.domain.nft.usecase.GetNftUseCase;
@@ -50,6 +51,16 @@ public class GetNftController {
         @PathVariable(name = "memberId") Long memberId) {
         return new ResponseEntity<>(
             getNftUseCase.getProfileNftList(member, memberId, pageRequestDto), HttpStatus.OK);
+    }
+
+    /**
+     * 내가 소유한 NFT 목록 보기 Api
+     */
+    @GetMapping("/common/nft/own")
+    public ResponseEntity<PageResponseDto<List<SnsNft>>> getMyOwnNftList(
+            @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto) {
+        return new ResponseEntity<>(
+                getNftUseCase.getMyOwnNftList(member, pageRequestDto), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
+++ b/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
@@ -7,7 +7,6 @@ import com.service.dida.domain.nft.usecase.GetNftUseCase;
 import com.service.dida.global.common.dto.PageRequestDto;
 import com.service.dida.global.common.dto.PageResponseDto;
 import com.service.dida.global.config.security.auth.CurrentMember;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +14,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -50,4 +51,5 @@ public class GetNftController {
         return new ResponseEntity<>(
             getNftUseCase.getProfileNftList(member, memberId, pageRequestDto), HttpStatus.OK);
     }
+
 }

--- a/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
+++ b/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.nft.dto;
 
 import com.service.dida.domain.member.dto.MemberResponseDto.MemberInfo;
+import com.service.dida.domain.nft.Nft;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,5 +36,24 @@ public class NftResponseDto {
     public static class ProfileNft {
         private NftInfo nftInfo;
         private boolean liked;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class SnsNft {
+        private Long nftId;
+        private String nftName;
+        private String nftImgUrl;
+        private MemberInfo memberInfo;
+
+        public SnsNft(Nft nft) {
+            this.nftId = nft.getNftId();
+            this.nftName = nft.getTitle();
+            this.nftImgUrl = nft.getImgUrl();
+            this.memberInfo = new MemberInfo(
+                    nft.getMember().getMemberId(),
+                    nft.getMember().getNickname(),
+                    nft.getMember().getProfileUrl());
+        }
     }
 }

--- a/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
+++ b/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
@@ -56,4 +56,23 @@ public class NftResponseDto {
                     nft.getMember().getProfileUrl());
         }
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class NftAndMemberInfo{
+        private NftInfo nftInfo;
+        private MemberInfo memberInfo;
+
+        public NftAndMemberInfo(Nft nft) {
+            this.nftInfo = new NftInfo(
+                    nft.getNftId(),
+                    nft.getTitle(),
+                    nft.getImgUrl(),
+                    nft.getPrice());
+            this.memberInfo = new MemberInfo(
+                    nft.getMember().getMemberId(),
+                    nft.getMember().getNickname(),
+                    nft.getMember().getProfileUrl());
+        }
+    }
 }

--- a/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
+++ b/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
@@ -44,4 +44,5 @@ public interface NftRepository extends JpaRepository<Nft, Long> {
 
     @Query(value = "SELECT COUNT(n) FROM Nft n WHERE n.deleted=false AND n.member=:member")
     Optional<Long> countByMemberWithDeleted(Member member);
+
 }

--- a/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
+++ b/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
@@ -6,6 +6,7 @@ import com.service.dida.domain.member.dto.MemberResponseDto.MemberInfo;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.member.repository.MemberRepository;
 import com.service.dida.domain.nft.Nft;
+import com.service.dida.domain.nft.dto.NftResponseDto.SnsNft;
 import com.service.dida.domain.nft.dto.NftResponseDto.NftDetailInfo;
 import com.service.dida.domain.nft.dto.NftResponseDto.NftInfo;
 import com.service.dida.domain.nft.dto.NftResponseDto.ProfileNft;
@@ -72,5 +73,15 @@ public class GetNftService implements GetNftUseCase {
             getLikeUseCase.checkIsLiked(member, n))));
 
         return new PageResponseDto<>(nfts.getNumber(), nfts.getSize(), nfts.hasNext(), profileNfts);
+    }
+
+    @Override
+    public PageResponseDto<List<SnsNft>> getMyOwnNftList(Member member, PageRequestDto pageRequestDto) {
+        List<SnsNft> res = new ArrayList<>();
+        Page<Nft> nfts = nftRepository.findAllNftsByMember(member, pageReq(pageRequestDto));
+
+        nfts.forEach(nft -> res.add(new SnsNft(nft)));
+
+        return new PageResponseDto<>(nfts.getNumber(), nfts.getSize(), nfts.hasNext(), res);
     }
 }

--- a/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
+++ b/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
@@ -1,7 +1,5 @@
 package com.service.dida.domain.nft.service;
 
-import static com.service.dida.global.config.exception.errorCode.NftErrorCode.EMPTY_NFT;
-
 import com.service.dida.domain.follow.usecase.GetFollowUseCase;
 import com.service.dida.domain.like.usecase.GetLikeUseCase;
 import com.service.dida.domain.member.dto.MemberResponseDto.MemberInfo;
@@ -17,13 +15,16 @@ import com.service.dida.global.common.dto.PageRequestDto;
 import com.service.dida.global.common.dto.PageResponseDto;
 import com.service.dida.global.config.exception.BaseException;
 import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.service.dida.global.config.exception.errorCode.NftErrorCode.EMPTY_NFT;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/service/dida/domain/nft/usecase/GetNftUseCase.java
+++ b/src/main/java/com/service/dida/domain/nft/usecase/GetNftUseCase.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.nft.usecase;
 
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.dto.NftResponseDto;
 import com.service.dida.domain.nft.dto.NftResponseDto.NftDetailInfo;
 import com.service.dida.domain.nft.dto.NftResponseDto.ProfileNft;
 import com.service.dida.global.common.dto.PageRequestDto;
@@ -12,4 +13,6 @@ public interface GetNftUseCase {
     NftDetailInfo getNftDetail(Member member,Long nftId);
 
     PageResponseDto<List<ProfileNft>> getProfileNftList(Member member,Long memberId, PageRequestDto pageRequestDto);
+
+    PageResponseDto<List<NftResponseDto.SnsNft>> getMyOwnNftList(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/post/controller/GetPostController.java
+++ b/src/main/java/com/service/dida/domain/post/controller/GetPostController.java
@@ -56,4 +56,15 @@ public class GetPostController {
             throws BaseException {
         return new ResponseEntity<>(getPostUseCase.getPost(member, postId), HttpStatus.OK);
     }
+
+    /**
+     * 시끌벅적 게시판 조회하기
+     * [GET] /posts/hot
+     */
+    @GetMapping("/posts/hot")
+    public ResponseEntity<PageResponseDto<List<PostResponseDto.GetHotPosts>>> getHotPosts(
+            @CurrentMember Member member, @RequestBody PageRequestDto pageRequestDto)
+            throws BaseException {
+        return new ResponseEntity<>(getPostUseCase.getHotPosts(member, pageRequestDto), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/service/dida/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/service/dida/domain/post/dto/PostResponseDto.java
@@ -30,4 +30,14 @@ public class PostResponseDto {
         private List<GetCommentResponseDto> comments; // 미리보기 댓글, 최대 3개
     }
 
+    @Getter
+    @AllArgsConstructor
+    public static class GetHotPosts {
+        private Long postId;
+        private String title;
+        private int commentCnt;
+        private Long nftId;
+        private String nftImgUrl;
+    }
+
 }

--- a/src/main/java/com/service/dida/domain/post/usecase/GetPostUseCase.java
+++ b/src/main/java/com/service/dida/domain/post/usecase/GetPostUseCase.java
@@ -16,4 +16,5 @@ public interface GetPostUseCase {
     PageResponseDto<List<PostResponseDto.GetPostResponseDto>> getPostsByNftId(Member member, Long nftId, PageRequestDto pageRequestDto);
     PostResponseDto.GetPostResponseDto getPost(Member member, Long postId);
     String checkIsMe(Member member, Member owner);
+    PageResponseDto<List<PostResponseDto.GetHotPosts>> getHotPosts(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/service/dida/domain/transaction/repository/TransactionRepository.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.transaction.repository;
 
 import com.service.dida.domain.member.entity.Member;
+import com.service.dida.domain.nft.Nft;
 import com.service.dida.domain.transaction.Transaction;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -40,4 +41,13 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
             "AND t.createdAt >:date AND COUNT(t.buyerId) >= 10 GROUP BY t.buyerId ORDER BY COUNT(t.buyerId) DESC")
     Page<Long> getHotMembersWithoutHide(Member member, LocalDateTime date, PageRequest pageRequest);
 
+    @Query(value = "SELECT t.nft FROM Transaction t WHERE t.type='DEAL' " +
+            "AND (t.sellerId) NOT IN (SELECT mh.hideMember.memberId FROM MemberHide mh WHERE mh.member=:member) " +
+            "AND (t.nft) NOT IN (SELECT nh.nft FROM NftHide nh WHERE nh.member=:member) " +
+            "AND t.createdAt> :date ORDER BY t.payAmount DESC ")
+    Page<Nft> getSoldOutWithoutHide(Member member, LocalDateTime date, PageRequest pageRequest);
+
+    @Query(value = "SELECT t.nft FROM Transaction t WHERE t.type='DEAL' " +
+            "AND t.createdAt> :date ORDER BY t.payAmount DESC ")
+    Page<Nft> getSoldOut(LocalDateTime date, PageRequest pageRequest);
 }

--- a/src/main/java/com/service/dida/domain/transaction/usecase/GetTransactionUseCase.java
+++ b/src/main/java/com/service/dida/domain/transaction/usecase/GetTransactionUseCase.java
@@ -20,4 +20,5 @@ public interface GetTransactionUseCase {
 
     PageResponseDto<List<DealingHistory>> getSoldDealingHistory(Member member,
         PageRequestDto pageRequestDto);
+
 }

--- a/src/main/java/com/service/dida/global/config/exception/errorCode/MarketErrorCode.java
+++ b/src/main/java/com/service/dida/global/config/exception/errorCode/MarketErrorCode.java
@@ -12,6 +12,7 @@ public enum MarketErrorCode implements ErrorCode {
     INVALID_PRICE("MARKET_002", "가격이 적절하지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_MEMBER("MARKET_003", "본인의 Market이 아닙니다.", HttpStatus.BAD_REQUEST),
     ITS_YOUR_MARKET("MARKET_004", "본인의 NFT는 구매할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_TERM("MARKET_005", "유효한 기간이 아닙니다.", HttpStatus.BAD_REQUEST),
     ;
     private final String errorCode;
     private final String message;


### PR DESCRIPTION
### 요약

- 내가 좋아요한 NFT 목록 조회
- 내가 보유한 NFT 목록 조회
- 시끌벅적 게시판 조회
- 메인화면 sold out 조회
- sold out 더보기 
### 상세 내용

- 내가 좋아요한 NFT 목록과 보유한 NFT 목록은 게시글 작성 직전 단계에 사용되는 API 입니다. 숨김 처리 시 좋아요가 취소하도록 코드를 구현해놔서 따로 숨김 여부는 고려해주지 않았습니다!
- 시끌벅적 게시판 같은 경우 figma에서 5개로 표시가 되어있는건지 애매해서, 그냥 페이징처리 했습니다! 더 많이 보여줄 수도 있으니까요!! 기준은 일주일 내 가장 댓글(삭제 제외)이 많이 달린 순입니다. 로그인 시 숨김 여부를 고려하여 구현했습니다.
- 메인화면 sold out 조회는 sold out 더보기와 같은 쿼리를 사용했습니다! 페이징 여부만 다릅니다. 로그인 시 숨김 여부를 고려하여 구현했습니다.

### 질문 및 이외 사항

- 아래처럼 DTO 자체에 생성자를 만들었는데 괜찮겠죠!??.. 처음 써보는 방식인데 이렇게 하면 Service 단에서 Nft만 넘겨주면 되더라고요! 한 번 사용해보았습니다!..
```
    @Getter
    @AllArgsConstructor
    public static class NftAndMemberInfo{
        private NftInfo nftInfo;
        private MemberInfo memberInfo;

        public NftAndMemberInfo(Nft nft) {
            this.nftInfo = new NftInfo(
                    nft.getNftId(),
                    nft.getTitle(),
                    nft.getImgUrl(),
                    nft.getPrice());
            this.memberInfo = new MemberInfo(
                    nft.getMember().getMemberId(),
                    nft.getMember().getNickname(),
                    nft.getMember().getProfileUrl());
        }
    }
```
### 이슈 번호

- close #60 
- close #61 
- close #59
- close #42 
- close #47