### PR TITLE
커뮤니티 알람 생성 추가

### DIFF
--- a/src/main/java/com/service/dida/domain/comment/controller/RegisterCommentController.java
+++ b/src/main/java/com/service/dida/domain/comment/controller/RegisterCommentController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+
 @RestController
 @AllArgsConstructor
 public class RegisterCommentController {
@@ -27,7 +29,7 @@ public class RegisterCommentController {
     public ResponseEntity<Integer> registerComment(
             @CurrentMember Member member,
             @RequestBody @Valid PostCommentRequestDto postCommentRequestDto)
-            throws BaseException {
+            throws BaseException, IOException {
         registerCommentUseCase.registerComment(member, postCommentRequestDto);
         return new ResponseEntity<>(200, HttpStatus.OK);
     }

--- a/src/main/java/com/service/dida/domain/comment/service/RegisterCommentService.java
+++ b/src/main/java/com/service/dida/domain/comment/service/RegisterCommentService.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.comment.service;
 
+import com.service.dida.domain.alarm.usecase.RegisterAlarmUseCase;
 import com.service.dida.domain.comment.Comment;
 import com.service.dida.domain.comment.dto.CommentRequestDto.PostCommentRequestDto;
 import com.service.dida.domain.comment.repository.CommentRepository;
@@ -13,20 +14,23 @@ import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+
 @Service
 @AllArgsConstructor
+@Transactional
 public class RegisterCommentService implements RegisterCommentUseCase {
 
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
-    @Transactional
+    private final RegisterAlarmUseCase registerAlarmUseCase;
+
     public void save(Comment comment) {
         commentRepository.save(comment);
     }
 
     @Override
-    @Transactional
-    public void registerComment(Member member, PostCommentRequestDto postCommentRequestDto) {
+    public void registerComment(Member member, PostCommentRequestDto postCommentRequestDto) throws IOException {
         Post post = postRepository.findByPostIdWithDeleted(postCommentRequestDto.getPostId())
                 .orElseThrow(() -> new BaseException(PostErrorCode.EMPTY_POST));
 
@@ -37,5 +41,6 @@ public class RegisterCommentService implements RegisterCommentUseCase {
                 .build();
 
         save(comment);
+        registerAlarmUseCase.registerCommentAlarm(post.getMember(), comment.getCommentId());
     }
 }

--- a/src/main/java/com/service/dida/domain/comment/usecase/RegisterCommentUseCase.java
+++ b/src/main/java/com/service/dida/domain/comment/usecase/RegisterCommentUseCase.java
@@ -3,6 +3,8 @@ package com.service.dida.domain.comment.usecase;
 import com.service.dida.domain.comment.dto.CommentRequestDto;
 import com.service.dida.domain.member.entity.Member;
 
+import java.io.IOException;
+
 public interface RegisterCommentUseCase {
-    void registerComment(Member member, CommentRequestDto.PostCommentRequestDto postCommentRequestDto);
+    void registerComment(Member member, CommentRequestDto.PostCommentRequestDto postCommentRequestDto) throws IOException;
 }

--- a/src/main/java/com/service/dida/domain/like/controller/RegisterLikeController.java
+++ b/src/main/java/com/service/dida/domain/like/controller/RegisterLikeController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+
 @RestController
 @RequiredArgsConstructor
 public class RegisterLikeController {
@@ -25,7 +27,7 @@ public class RegisterLikeController {
     @PostMapping("/common/nft/like")
     public ResponseEntity<Boolean> pushLike(
             @RequestParam("nftId") Long nftId, @CurrentMember Member member)
-            throws BaseException {
+            throws BaseException, IOException {
         return new ResponseEntity<>(registerLikeUseCase.pushLike(member, nftId), HttpStatus.OK);
     }
 

--- a/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
@@ -43,7 +43,7 @@ public class RegisterLikeService implements RegisterLikeUseCase {
         Like like = likeRepository.findByMemberAndNft(member, nft).orElse(null);
         if (like == null) {
             createLike(member, nft);
-            registerAlarmUseCase.registerLikeAlarm(member, nft.getNftId());
+            registerAlarmUseCase.registerLikeAlarm(nft.getMember(), nft.getNftId());
             return true;
         } else {
             return like.changeStatus();

--- a/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.like.service;
 
 
+import com.service.dida.domain.alarm.usecase.RegisterAlarmUseCase;
 import com.service.dida.domain.like.Like;
 import com.service.dida.domain.like.repository.LikeRepository;
 import com.service.dida.domain.like.usecase.RegisterLikeUseCase;
@@ -8,19 +9,21 @@ import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
 import com.service.dida.domain.nft.repository.NftRepository;
 import com.service.dida.global.config.exception.BaseException;
-import com.service.dida.global.config.exception.errorCode.MemberErrorCode;
 import com.service.dida.global.config.exception.errorCode.NftErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class RegisterLikeService implements RegisterLikeUseCase {
     private final LikeRepository likeRepository;
     private final NftRepository nftRepository;
+    private final RegisterAlarmUseCase registerAlarmUseCase;
 
-    @Transactional
     public void save(Like like) {
         likeRepository.save(like);
     }
@@ -33,14 +36,14 @@ public class RegisterLikeService implements RegisterLikeUseCase {
     }
 
     @Override
-    @Transactional
-    public boolean pushLike(Member member, Long nftId) {
+    public boolean pushLike(Member member, Long nftId) throws IOException {
         Nft nft = nftRepository.findByNftIdWithDeleted(nftId)
                 .orElseThrow(() -> new BaseException(NftErrorCode.EMPTY_NFT));
 
         Like like = likeRepository.findByMemberAndNft(member, nft).orElse(null);
         if (like == null) {
             createLike(member, nft);
+            registerAlarmUseCase.registerLikeAlarm(member, nft.getNftId());
             return true;
         } else {
             return like.changeStatus();

--- a/src/main/java/com/service/dida/domain/like/usecase/RegisterLikeUseCase.java
+++ b/src/main/java/com/service/dida/domain/like/usecase/RegisterLikeUseCase.java
@@ -2,6 +2,8 @@ package com.service.dida.domain.like.usecase;
 
 import com.service.dida.domain.member.entity.Member;
 
+import java.io.IOException;
+
 public interface RegisterLikeUseCase {
-    boolean pushLike(Member member, Long nftId);
+    boolean pushLike(Member member, Long nftId) throws IOException;
 }


### PR DESCRIPTION
### 요약

- NFT 좋아요 알람
- 댓글 좋아요 알람
### 상세 내용

- 만들어주신 registerCommentAlarm과 registerLikeAlram 함수를 이용했습니다!
### 질문 및 이외 사항

- 처음에 [Feat: NFT 좋아요 알람 추가](https://github.com/service-dida/back_end/commit/01fbd399107b5606bdbe96e30f54ed0af8c16620)에서는 `registerLikeAlram` 의 member 파리미터에 `좋아요를 누른 Member`를 넘겼었는데 다시 읽어보니 `NFT의 주인인 Member` 가 들어가야겠더라고요!! [Fix: NFT 좋아요 알람 Member 수정](https://github.com/service-dida/back_end/commit/6cc837909e18bbe294394658119c9907cb4031a3) 에서 수정했습니다!!
### 이슈 번호

- 