### PR TITLE
NFT 보유화면 정렬기능 추가

### DIFF
--- a/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
+++ b/src/main/java/com/service/dida/domain/nft/controller/GetNftController.java
@@ -34,10 +34,11 @@ public class GetNftController {
      */
     @GetMapping("/common/profile/nft")
     public ResponseEntity<PageResponseDto<List<ProfileNft>>> getProfileNftList(
-            @CurrentMember Member member,
-            @RequestParam("page") int page, @RequestParam("size") int size) {
+        @CurrentMember Member member,
+        @RequestParam("page") int page, @RequestParam("size") int size,
+        @RequestParam("sort") String sort) {
         return new ResponseEntity<>(getNftUseCase.getProfileNftList(member, null,
-                new PageRequestDto(page, size)),
+            new PageRequestDto(page, size), sort),
             HttpStatus.OK);
     }
 
@@ -46,10 +47,13 @@ public class GetNftController {
      */
     @GetMapping("/profile/nft/{memberId}")
     public ResponseEntity<PageResponseDto<List<ProfileNft>>> getOtherProfileNftList(
-        @CurrentMember Member member, @RequestParam("page") int page, @RequestParam("size") int size,
-        @PathVariable(name = "memberId") Long memberId) {
+        @CurrentMember Member member, @RequestParam("page") int page,
+        @RequestParam("size") int size,
+        @PathVariable(name = "memberId") Long memberId,
+        @RequestParam("sort") String sort) {
         return new ResponseEntity<>(
-            getNftUseCase.getProfileNftList(member, memberId, new PageRequestDto(page, size)), HttpStatus.OK);
+            getNftUseCase.getProfileNftList(member, memberId, new PageRequestDto(page, size), sort),
+            HttpStatus.OK);
     }
 
     /**
@@ -57,9 +61,10 @@ public class GetNftController {
      */
     @GetMapping("/common/nft/own")
     public ResponseEntity<PageResponseDto<List<SnsNft>>> getMyOwnNftList(
-            @CurrentMember Member member, @RequestParam("page") int page, @RequestParam("size") int size) {
+        @CurrentMember Member member, @RequestParam("page") int page,
+        @RequestParam("size") int size) {
         return new ResponseEntity<>(
-                getNftUseCase.getMyOwnNftList(member, new PageRequestDto(page, size)), HttpStatus.OK);
+            getNftUseCase.getMyOwnNftList(member, new PageRequestDto(page, size)), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/service/dida/domain/nft/usecase/GetNftUseCase.java
+++ b/src/main/java/com/service/dida/domain/nft/usecase/GetNftUseCase.java
@@ -10,9 +10,11 @@ import java.util.List;
 
 public interface GetNftUseCase {
 
-    NftDetailInfo getNftDetail(Member member,Long nftId);
+    NftDetailInfo getNftDetail(Member member, Long nftId);
 
-    PageResponseDto<List<ProfileNft>> getProfileNftList(Member member,Long memberId, PageRequestDto pageRequestDto);
+    PageResponseDto<List<ProfileNft>> getProfileNftList(Member member, Long memberId,
+        PageRequestDto pageRequestDto, String sort);
 
-    PageResponseDto<List<NftResponseDto.SnsNft>> getMyOwnNftList(Member member, PageRequestDto pageRequestDto);
+    PageResponseDto<List<NftResponseDto.SnsNft>> getMyOwnNftList(Member member,
+        PageRequestDto pageRequestDto);
 }


### PR DESCRIPTION
### 요약

- NFT 보유화면 정렬기능 추가
### 상세 내용

- 사용자의 NFT 보유 목록을 볼때 오름차순과 내림차순의 정렬 추가
### 질문 및 이외 사항

- updated_desc, updated_asc 가 아니라면 오류처리
### 이슈 번호

- 