### PR TITLE
NFT 좋아요 누르기 status default 값 수정

### DIFF
--- a/src/main/java/com/service/dida/domain/like/Like.java
+++ b/src/main/java/com/service/dida/domain/like/Like.java
@@ -37,7 +37,7 @@ public class Like extends BaseEntity {
     @JoinColumn(name = "nft_id")
     private Nft nft;
 
-    @Column(name = "status", nullable = false, columnDefinition = "boolean default true")
+    @Column(name = "status", nullable = false)
     private boolean status;
 
     public boolean changeStatus() {

--- a/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
@@ -32,6 +32,7 @@ public class RegisterLikeService implements RegisterLikeUseCase {
         save(Like.builder()
                 .member(member)
                 .nft(nft)
+                .status(true)
                 .build());
     }
 


### PR DESCRIPTION
### 요약

- NFT  좋아요 누르기에서 DB에 status 초기 값이 false로 들어가는 에러 수정
### 상세 내용

- 
### 질문 및 이외 사항

- 
### 이슈 번호

- 