### PR TITLE
NFT 목록 조회 및 메인화면 Soldout 조회 API 수정

### DIFF
--- a/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
+++ b/src/main/java/com/service/dida/domain/market/controller/GetMarketController.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.market.controller;
 
+import com.service.dida.domain.market.dto.MarketResponseDto;
 import com.service.dida.domain.market.dto.MarketResponseDto.GetMainPageWithoutSoldOut;
 import com.service.dida.domain.market.dto.MarketResponseDto.GetRecentNft;
 import com.service.dida.domain.market.dto.MarketResponseDto.MoreHotMember;
@@ -39,7 +40,7 @@ public class GetMarketController {
      * [GET] /main/sold-out
      */
     @GetMapping("/main/sold-out")
-    public ResponseEntity<List<NftAndMemberInfo>> getMainPageSoldOut(
+    public ResponseEntity<MarketResponseDto.GetMainSoldOut> getMainPageSoldOut(
             @CurrentMember Member member, @RequestParam("range") int range)
             throws BaseException {
         return new ResponseEntity<>(getMarketUseCase.getMainPageSoldOut(member, range, 0, 3), HttpStatus.OK);

--- a/src/main/java/com/service/dida/domain/market/dto/MarketResponseDto.java
+++ b/src/main/java/com/service/dida/domain/market/dto/MarketResponseDto.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.market.dto;
 
+import com.service.dida.domain.nft.dto.NftResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -64,5 +65,11 @@ public class MarketResponseDto {
     public static class MoreHotMember {
         private GetHotMember memberInfo;
         private List<String> nftImgUrl;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class GetMainSoldOut {
+        private List<NftResponseDto.NftAndMemberInfo> nftAndMemberInfos;
     }
 }

--- a/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
+++ b/src/main/java/com/service/dida/domain/market/service/GetMarketService.java
@@ -58,11 +58,11 @@ public class GetMarketService implements GetMarketUseCase {
     }
 
     @Override
-    public List<NftAndMemberInfo> getMainPageSoldOut(Member member, int range, int page, int limit) {
+    public GetMainSoldOut getMainPageSoldOut(Member member, int range, int page, int limit) {
         List<NftAndMemberInfo> res = new ArrayList<>();
         Page<Nft> nfts = getSoldOutPage(member, range, page, limit);
         nfts.forEach(n -> res.add(new NftAndMemberInfo(n)));
-        return res;
+        return new GetMainSoldOut(res);
     }
 
     @Override

--- a/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
+++ b/src/main/java/com/service/dida/domain/market/usecase/GetMarketUseCase.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface GetMarketUseCase {
 
     GetMainPageWithoutSoldOut getMainPage(Member member);
-    List<NftResponseDto.NftAndMemberInfo> getMainPageSoldOut(Member member, int range, int page, int limit);
+    MarketResponseDto.GetMainSoldOut getMainPageSoldOut(Member member, int range, int page, int limit);
     PageResponseDto<List<NftResponseDto.NftAndMemberInfo>> getMoreSoldOuts(Member member, int range, PageRequestDto pageRequestDto);
     PageResponseDto<List<MarketResponseDto.MoreHotMember>> getMoreHotSellers(Member member, PageRequestDto pageRequestDto);
     PageResponseDto<List<MarketResponseDto.GetRecentNft>> getMoreRecentNfts(Member member, PageRequestDto pageRequestDto);

--- a/src/main/java/com/service/dida/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/service/dida/domain/member/dto/MemberResponseDto.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.member.dto;
 
+import com.service.dida.domain.member.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,6 +28,12 @@ public class MemberResponseDto {
         private Long memberId;
         private String memberName;
         private String profileImgUrl;
+
+        public MemberInfo(Member member) {
+            this.memberId = member.getMemberId();
+            this.memberName = member.getNickname();
+            this.profileImgUrl = member.getProfileUrl();
+        }
     }
 
     @Getter

--- a/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
+++ b/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
@@ -36,6 +36,7 @@ public class NftResponseDto {
     @AllArgsConstructor
     public static class ProfileNft {
         private NftInfo nftInfo;
+        private MemberInfo memberInfo;
         private boolean liked;
     }
 

--- a/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
+++ b/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
@@ -87,7 +87,7 @@ public class GetNftService implements GetNftUseCase {
         }
         nfts.forEach(n -> profileNfts.add(new ProfileNft(
             new NftInfo(n.getNftId(), n.getTitle(), n.getImgUrl(), n.getPrice()),
-            getLikeUseCase.checkIsLiked(member, n))));
+                new MemberInfo(n.getMember()), getLikeUseCase.checkIsLiked(member, n))));
 
         return new PageResponseDto<>(nfts.getNumber(), nfts.getSize(), nfts.hasNext(), profileNfts);
     }


### PR DESCRIPTION
### 요약

- NFT 목록 조회 및 메인화면 Soldout 조회 API 수정
### 상세 내용

- [내 NFT 및 타인 NFT 조회 API에 MemberInfo 추가](https://github.com/service-dida/back_end/commit/e7e7f24cce9aa0d072f8d31aa3bfc118cabd98e3)
- [메인화면 Sold Out 조회 Json Mapping](https://github.com/service-dida/back_end/commit/256be29b6abcbb2345c336fd5473e8fc7852e93e)
### 질문 및 이외 사항

- 
### 이슈 번호

- 