### PR TITLE
프로필 - 보유한 NFT 조회 API 쿼리 수정

### DIFF
--- a/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
+++ b/src/main/java/com/service/dida/domain/nft/dto/NftResponseDto.java
@@ -36,7 +36,7 @@ public class NftResponseDto {
     @AllArgsConstructor
     public static class ProfileNft {
         private NftInfo nftInfo;
-        private MemberInfo memberInfo;
+        private String memberName;
         private boolean liked;
     }
 

--- a/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
+++ b/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
@@ -22,7 +22,8 @@ public interface NftRepository extends JpaRepository<Nft, Long> {
 
     Integer countByMemberAndDeleted(Member member, boolean deleted);
 
-    @Query(value = "SELECT n FROM Nft n WHERE n.member = :member AND n.deleted = false")
+    @Query(value = "SELECT n FROM Nft n JOIN FETCH n.market WHERE n.member = :member AND n.deleted = false",
+            countQuery = "SELECT count(n) FROM Nft n")
     Page<Nft> findAllNftsByMember(Member member, PageRequest pageRequest);
 
     @Query(value = "SELECT n.imgUrl FROM Nft n " +

--- a/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
+++ b/src/main/java/com/service/dida/domain/nft/repository/NftRepository.java
@@ -22,7 +22,7 @@ public interface NftRepository extends JpaRepository<Nft, Long> {
 
     Integer countByMemberAndDeleted(Member member, boolean deleted);
 
-    @Query(value = "SELECT n FROM Nft n JOIN FETCH n.market WHERE n.member = :member AND n.deleted = false",
+    @Query(value = "SELECT n FROM Nft n LEFT JOIN FETCH n.market WHERE n.member = :member AND n.deleted = false",
             countQuery = "SELECT count(n) FROM Nft n")
     Page<Nft> findAllNftsByMember(Member member, PageRequest pageRequest);
 

--- a/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
+++ b/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
@@ -66,6 +66,7 @@ public class GetNftService implements GetNftUseCase {
         checkSortingWord(sort);
         List<ProfileNft> profileNfts = new ArrayList<>();
         Page<Nft> nfts = null;
+        MemberInfo memberInfo;
         if (memberId == null) {
             if (sort.equals("updated_desc")) {
                 nfts = nftRepository.findAllNftsByMember(member,
@@ -74,6 +75,7 @@ public class GetNftService implements GetNftUseCase {
                 nfts = nftRepository.findAllNftsByMember(member,
                     pageReq(pageRequestDto, Direction.ASC));
             }
+            memberInfo = new MemberInfo(member);
         } else {
             Member other = memberRepository.findByMemberIdWithDeleted(memberId).orElseThrow(() ->
                 new BaseException(MemberErrorCode.EMPTY_MEMBER));
@@ -84,10 +86,11 @@ public class GetNftService implements GetNftUseCase {
                 nfts = nftRepository.findAllNftsByMember(other,
                     pageReq(pageRequestDto, Direction.ASC));
             }
+            memberInfo = new MemberInfo(other);
         }
         nfts.forEach(n -> profileNfts.add(new ProfileNft(
             new NftInfo(n.getNftId(), n.getTitle(), n.getImgUrl(), n.getPrice()),
-                new MemberInfo(n.getMember()), getLikeUseCase.checkIsLiked(member, n))));
+                memberInfo, getLikeUseCase.checkIsLiked(member, n))));
 
         return new PageResponseDto<>(nfts.getNumber(), nfts.getSize(), nfts.hasNext(), profileNfts);
     }

--- a/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
+++ b/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
@@ -66,7 +66,7 @@ public class GetNftService implements GetNftUseCase {
         checkSortingWord(sort);
         List<ProfileNft> profileNfts = new ArrayList<>();
         Page<Nft> nfts = null;
-        MemberInfo memberInfo;
+        String memberName;
         if (memberId == null) {
             if (sort.equals("updated_desc")) {
                 nfts = nftRepository.findAllNftsByMember(member,
@@ -75,7 +75,7 @@ public class GetNftService implements GetNftUseCase {
                 nfts = nftRepository.findAllNftsByMember(member,
                     pageReq(pageRequestDto, Direction.ASC));
             }
-            memberInfo = new MemberInfo(member);
+            memberName = member.getNickname();
         } else {
             Member other = memberRepository.findByMemberIdWithDeleted(memberId).orElseThrow(() ->
                 new BaseException(MemberErrorCode.EMPTY_MEMBER));
@@ -86,11 +86,11 @@ public class GetNftService implements GetNftUseCase {
                 nfts = nftRepository.findAllNftsByMember(other,
                     pageReq(pageRequestDto, Direction.ASC));
             }
-            memberInfo = new MemberInfo(other);
+            memberName = other.getNickname();
         }
         nfts.forEach(n -> profileNfts.add(new ProfileNft(
             new NftInfo(n.getNftId(), n.getTitle(), n.getImgUrl(), n.getPrice()),
-                memberInfo, getLikeUseCase.checkIsLiked(member, n))));
+                memberName, getLikeUseCase.checkIsLiked(member, n))));
 
         return new PageResponseDto<>(nfts.getNumber(), nfts.getSize(), nfts.hasNext(), profileNfts);
     }


### PR DESCRIPTION
### 요약

- 보유한 NFT 조회 API 쿼리 리팩토링
- Response에 MemberInfo -> memberName으로 수정
### 상세 내용

- 문제 상황
아래 쿼리 실행 시 페이지의 size 만큼 market에 대한 SELECT 문이 나감
좋아요도 같은 상황이라서 API 1번 호출 시 약 25번(1 페이지에 NFT 10개라고 했을 때 market SELECT 문 10번 + like SELECT 문 10번 + 기타 등등)의 쿼리가 실행
```
    @Query(value = "SELECT n FROM Nft n WHERE n.member = :member AND n.deleted = false")
    Page<Nft> findAllNftsByMember(Member member, PageRequest pageRequest);
```
- 해결 방법
처음에는 JOIN FETCH를 했으나 market에 등록되지 않은 nft는 market이 null 이기 때문에, market에 등록되지 않은 nft는 아예 조회되지 않는 문제 발생! 따라서 LEFT JOIN FETCH를 통해 market 정보도 함께 가져와줌
페이징을 적용한 쿼리의 경우 뒤에 `countQuery = "SELECT count(n) FROM Nft n` 를 붙여주어야 함
```
    @Query(value = "SELECT n FROM Nft n LEFT JOIN FETCH n.market WHERE n.member = :member AND n.deleted = false",
            countQuery = "SELECT count(n) FROM Nft n")
    Page<Nft> findAllNftsByMember(Member member, PageRequest pageRequest);
```
### 질문 및 이외 사항

- 
### 이슈 번호

- 