### PR TITLE
NFT확인 Api 수정 및 미로그인 수정

### DIFF
--- a/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
+++ b/src/main/java/com/service/dida/domain/nft/service/GetNftService.java
@@ -49,10 +49,17 @@ public class GetNftService implements GetNftUseCase {
         Nft nft = nftRepository.findByNftIdWithDeleted(nftId)
             .orElseThrow(() -> new BaseException(EMPTY_NFT));
         Member owner = nft.getMember();
-        boolean isMe = checkIsMe(member.getMemberId(), nft.getMember().getMemberId());
-        boolean followed = member != null && getFollowUseCase.checkIsFollowed(member, owner);
-        // boolean liked = member == null ? false : getLikeUseCase.checkIsLiked(member, nft) 와 같음
-        boolean liked = member != null && getLikeUseCase.checkIsLiked(member, nft);
+        boolean isMe, followed, liked;
+        if (member == null) {
+            isMe = false;
+            followed = false;
+            liked = false;
+        } else {
+            isMe = checkIsMe(member.getMemberId(), nft.getMember().getMemberId());
+            followed = getFollowUseCase.checkIsFollowed(member, owner);
+            // boolean liked = member == null ? false : getLikeUseCase.checkIsLiked(member, nft) 와 같음
+            liked = getLikeUseCase.checkIsLiked(member, nft);
+        }
         return new NftDetailInfo(
             new NftInfo(nft.getNftId(), nft.getTitle(), nft.getImgUrl(), nft.getPrice()),
             nft.getDescription(),
@@ -90,7 +97,7 @@ public class GetNftService implements GetNftUseCase {
         }
         nfts.forEach(n -> profileNfts.add(new ProfileNft(
             new NftInfo(n.getNftId(), n.getTitle(), n.getImgUrl(), n.getPrice()),
-                memberName, getLikeUseCase.checkIsLiked(member, n))));
+            memberName, getLikeUseCase.checkIsLiked(member, n))));
 
         return new PageResponseDto<>(nfts.getNumber(), nfts.getSize(), nfts.hasNext(), profileNfts);
     }
@@ -106,9 +113,9 @@ public class GetNftService implements GetNftUseCase {
 
         return new PageResponseDto<>(nfts.getNumber(), nfts.getSize(), nfts.hasNext(), res);
     }
-    
+
     public void checkSortingWord(String sort) {
-        if(!sort.equals("updated_desc") && !sort.equals("updated_asc")) {
+        if (!sort.equals("updated_desc") && !sort.equals("updated_asc")) {
             throw new BaseException(GlobalErrorCode.NOT_VALID_ARGUMENT_ERROR);
         }
     }

--- a/src/main/java/com/service/dida/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/service/dida/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -26,6 +27,11 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             .equals("/common/refresh") && jwtTokenProvider.validateRefreshToken(refreshToken)) {
             Authentication authentication = jwtTokenProvider.getRefreshAuthentication(refreshToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
+        }  else if(Objects.equals(token, "") && !((HttpServletRequest) request).getRequestURI()
+            .contains("/common") && !((HttpServletRequest) request).getRequestURI()
+            .contains("/member") && !((HttpServletRequest) request).getRequestURI()
+            .contains("/visitor")) {
+            SecurityContextHolder.getContext().setAuthentication(null);
         } else if (token != null && jwtTokenProvider.validateToken(token)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);


### PR DESCRIPTION
### 요약

- NFT 확인 에러 수정 및 미로그인 상태 변경
### 상세 내용

- NFT확인 API에서 미로그인 했을 시 NPE 방지
- 미로그인을 Authorization = ""로 수정
### 질문 및 이외 사항

- 앞으로 새로운 Api들도 기능에 맞게 uri에 common,member,visitor 을 적절히 사용해 줘야함
### 이슈 번호

- 