### PR TITLE
Market 삭제 시 Nft 가격이 남아 있는 버그 수정

### DIFF
--- a/src/main/java/com/service/dida/domain/market/service/UpdateMarketService.java
+++ b/src/main/java/com/service/dida/domain/market/service/UpdateMarketService.java
@@ -10,17 +10,18 @@ import com.service.dida.domain.wallet.usecase.WalletUseCase;
 import com.service.dida.global.config.exception.BaseException;
 import com.service.dida.global.config.exception.errorCode.MarketErrorCode;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.parser.ParseException;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Objects;
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import lombok.RequiredArgsConstructor;
-import org.json.simple.parser.ParseException;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +43,7 @@ public class UpdateMarketService implements UpdateMarketUseCase {
             throw new BaseException(MarketErrorCode.INVALID_MEMBER);
         }
         market.delete();
+        market.getNft().changeMarket(null);
     }
 
     @Override

--- a/src/main/java/com/service/dida/domain/nft/Nft.java
+++ b/src/main/java/com/service/dida/domain/nft/Nft.java
@@ -5,23 +5,13 @@ import com.service.dida.domain.market.Market;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.post.Post;
 import com.service.dida.global.common.BaseEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
-import java.util.List;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Builder
@@ -96,4 +86,5 @@ public class Nft extends BaseEntity {
     public void changeMarket(Market market) {
         this.market = market;
     }
+
 }


### PR DESCRIPTION
### 요약

- Market 삭제해도 Nft 가격이 남아 있는 버그를 수정했습니다.
### 상세 내용

- Nft 판매 취소 API 호출 시 Market을 삭제하더라도 Nft Entity에는 Market이 남아 있어, 가격이 그대로 뜨는 에러가 있었습니다.
- Market을 삭제할 때 Nft가 가지고 있는 Market도 null로 설정해주었습니다.
### 질문 및 이외 사항

- 
### 이슈 번호

- 