### PR TITLE
NFT 소유권 내역 및 키워드 확인 Api 추가

### DIFF
--- a/src/main/java/com/service/dida/domain/history/History.java
+++ b/src/main/java/com/service/dida/domain/history/History.java
@@ -1,0 +1,42 @@
+package com.service.dida.domain.history;
+
+import com.service.dida.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "history")
+public class History {
+    @Id
+    @Column(name = "history_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long historyId;
+
+    @Column(name = "nft_id")
+    private Long nftId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/service/dida/domain/history/controller/GetHistoryController.java
+++ b/src/main/java/com/service/dida/domain/history/controller/GetHistoryController.java
@@ -1,0 +1,30 @@
+package com.service.dida.domain.history.controller;
+
+import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnHistory;
+import com.service.dida.domain.history.usecase.GetHistoryUseCase;
+import com.service.dida.global.common.dto.PageRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GetHistoryController {
+
+    private final GetHistoryUseCase getHistoryUseCase;
+
+    /**
+     * NFT 소유권 내역 확인하기
+     */
+    @GetMapping("/history/{nftId}")
+    public ResponseEntity<NftOwnHistory> getNftOwnHistory(@RequestParam("page") int page,
+        @RequestParam("size") int size, @PathVariable Long nftId) {
+        return new ResponseEntity<>(
+            getHistoryUseCase.getNftOwnHistory(nftId, new PageRequestDto(page, size)),
+            HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/history/dto/HistoryResponseDto.java
+++ b/src/main/java/com/service/dida/domain/history/dto/HistoryResponseDto.java
@@ -1,0 +1,26 @@
+package com.service.dida.domain.history.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class HistoryResponseDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NftOwnData {
+        private LocalDateTime ownerDate;
+        private Long ownerId;
+        private String ownerName;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NftOwnHistory {
+        List<NftOwnData> nftOwnHistory;
+    }
+}

--- a/src/main/java/com/service/dida/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/com/service/dida/domain/history/repository/HistoryRepository.java
@@ -1,0 +1,12 @@
+package com.service.dida.domain.history.repository;
+
+import com.service.dida.domain.history.History;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HistoryRepository extends JpaRepository<History, Long> {
+
+
+    Page<History> findAllByNftId(Long nftId, PageRequest pageRequest);
+}

--- a/src/main/java/com/service/dida/domain/history/service/GetHistoryService.java
+++ b/src/main/java/com/service/dida/domain/history/service/GetHistoryService.java
@@ -1,0 +1,38 @@
+package com.service.dida.domain.history.service;
+
+import com.service.dida.domain.history.History;
+import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnData;
+import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnHistory;
+import com.service.dida.domain.history.repository.HistoryRepository;
+import com.service.dida.domain.history.usecase.GetHistoryUseCase;
+import com.service.dida.global.common.dto.PageRequestDto;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetHistoryService implements GetHistoryUseCase {
+
+    private final HistoryRepository historyRepository;
+
+    public PageRequest pageReq(PageRequestDto pageRequestDto) {
+        return PageRequest.of(pageRequestDto.getPage(), pageRequestDto.getPageSize()
+            , Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+    @Override
+    public NftOwnHistory getNftOwnHistory(Long nftId, PageRequestDto pageRequestDto) {
+        List<NftOwnData> nftOwnHistory = new ArrayList<>();
+        Page<History> histories = historyRepository.findAllByNftId(nftId, pageReq(pageRequestDto));
+        histories.forEach(h -> nftOwnHistory.add(
+            new NftOwnData(h.getCreatedAt(), h.getMember().getMemberId(),
+                h.getMember().getNickname())));
+
+        return new NftOwnHistory(nftOwnHistory);
+    }
+}

--- a/src/main/java/com/service/dida/domain/history/service/RegisterHistoryService.java
+++ b/src/main/java/com/service/dida/domain/history/service/RegisterHistoryService.java
@@ -1,0 +1,32 @@
+package com.service.dida.domain.history.service;
+
+import com.service.dida.domain.history.History;
+import com.service.dida.domain.history.repository.HistoryRepository;
+import com.service.dida.domain.history.usecase.RegisterHistoryUseCase;
+import com.service.dida.domain.member.entity.Member;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RegisterHistoryService implements RegisterHistoryUseCase {
+
+    private final HistoryRepository historyRepository;
+
+    private void save(History history) {
+        historyRepository.save(history);
+    }
+
+    @Override
+    public void registerHistory(Long nftId, Member member) {
+        History history = History.builder()
+            .createdAt(LocalDateTime.now())
+            .nftId(nftId)
+            .member(member)
+            .build();
+        save(history);
+    }
+}

--- a/src/main/java/com/service/dida/domain/history/usecase/GetHistoryUseCase.java
+++ b/src/main/java/com/service/dida/domain/history/usecase/GetHistoryUseCase.java
@@ -1,0 +1,8 @@
+package com.service.dida.domain.history.usecase;
+
+import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnHistory;
+import com.service.dida.global.common.dto.PageRequestDto;
+
+public interface GetHistoryUseCase {
+    NftOwnHistory getNftOwnHistory(Long nftId, PageRequestDto pageRequestDto);
+}

--- a/src/main/java/com/service/dida/domain/history/usecase/RegisterHistoryUseCase.java
+++ b/src/main/java/com/service/dida/domain/history/usecase/RegisterHistoryUseCase.java
@@ -1,0 +1,7 @@
+package com.service.dida.domain.history.usecase;
+
+import com.service.dida.domain.member.entity.Member;
+
+public interface RegisterHistoryUseCase {
+    void registerHistory(Long nftId, Member member);
+}

--- a/src/main/java/com/service/dida/domain/keyword/Keyword.java
+++ b/src/main/java/com/service/dida/domain/keyword/Keyword.java
@@ -1,0 +1,31 @@
+package com.service.dida.domain.keyword;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "keyword")
+public class Keyword {
+    @Id
+    @Column(name = "keyword_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long keywordId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "type", nullable = false)
+    private int type;
+}

--- a/src/main/java/com/service/dida/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/com/service/dida/domain/keyword/controller/KeywordController.java
@@ -2,8 +2,6 @@ package com.service.dida.domain.keyword.controller;
 
 import com.service.dida.domain.keyword.dto.KeywordResponseDto.GetKeywordList;
 import com.service.dida.domain.keyword.usecase.GetKeywordUseCase;
-import com.service.dida.domain.member.entity.Member;
-import com.service.dida.global.config.security.auth.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +19,7 @@ public class KeywordController {
      * [GET] /keyword
      */
     @GetMapping("/keyword")
-    public ResponseEntity<GetKeywordList> getKeywordList(@CurrentMember Member member) {
+    public ResponseEntity<GetKeywordList> getKeywordList() {
         return new ResponseEntity<>(getKeywordUseCase.getKeywordList(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/service/dida/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/com/service/dida/domain/keyword/controller/KeywordController.java
@@ -1,0 +1,27 @@
+package com.service.dida.domain.keyword.controller;
+
+import com.service.dida.domain.keyword.dto.KeywordResponseDto.GetKeywordList;
+import com.service.dida.domain.keyword.usecase.GetKeywordUseCase;
+import com.service.dida.domain.member.entity.Member;
+import com.service.dida.global.config.security.auth.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class KeywordController {
+
+    private final GetKeywordUseCase getKeywordUseCase;
+
+    /**
+     * 키워드 가져오기
+     * [GET] /keyword
+     */
+    @GetMapping("/keyword")
+    public ResponseEntity<GetKeywordList> getKeywordList(@CurrentMember Member member) {
+        return new ResponseEntity<>(getKeywordUseCase.getKeywordList(), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/service/dida/domain/keyword/dto/KeywordResponseDto.java
+++ b/src/main/java/com/service/dida/domain/keyword/dto/KeywordResponseDto.java
@@ -1,0 +1,17 @@
+package com.service.dida.domain.keyword.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class KeywordResponseDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetKeywordList {
+        List<String> things;
+        List<String> places;
+    }
+}

--- a/src/main/java/com/service/dida/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/service/dida/domain/keyword/repository/KeywordRepository.java
@@ -1,0 +1,9 @@
+package com.service.dida.domain.keyword.repository;
+
+import com.service.dida.domain.keyword.Keyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KeywordRepository extends JpaRepository<Keyword,Long> {
+
+
+}

--- a/src/main/java/com/service/dida/domain/keyword/service/GetKeywordService.java
+++ b/src/main/java/com/service/dida/domain/keyword/service/GetKeywordService.java
@@ -1,0 +1,33 @@
+package com.service.dida.domain.keyword.service;
+
+import com.service.dida.domain.keyword.Keyword;
+import com.service.dida.domain.keyword.dto.KeywordResponseDto.GetKeywordList;
+import com.service.dida.domain.keyword.repository.KeywordRepository;
+import com.service.dida.domain.keyword.usecase.GetKeywordUseCase;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetKeywordService implements GetKeywordUseCase {
+
+    private final KeywordRepository keywordRepository;
+
+
+    @Override
+    public GetKeywordList getKeywordList() {
+        List<String> things = new ArrayList<>();
+        List<String> places = new ArrayList<>();
+        List<Keyword> keywords = keywordRepository.findAll();
+        keywords.forEach(keyword -> {
+            if (keyword.getType() == 1) {
+                things.add(keyword.getName());
+            } else if (keyword.getType() == 2) {
+                places.add(keyword.getName());
+            }
+        });
+        return new GetKeywordList(things,places);
+    }
+}

--- a/src/main/java/com/service/dida/domain/keyword/usecase/GetKeywordUseCase.java
+++ b/src/main/java/com/service/dida/domain/keyword/usecase/GetKeywordUseCase.java
@@ -1,0 +1,8 @@
+package com.service.dida.domain.keyword.usecase;
+
+import com.service.dida.domain.keyword.dto.KeywordResponseDto.GetKeywordList;
+
+public interface GetKeywordUseCase {
+
+    GetKeywordList getKeywordList();
+}

--- a/src/main/java/com/service/dida/domain/market/service/UpdateMarketService.java
+++ b/src/main/java/com/service/dida/domain/market/service/UpdateMarketService.java
@@ -1,6 +1,7 @@
 package com.service.dida.domain.market.service;
 
 import com.service.dida.domain.alarm.usecase.RegisterAlarmUseCase;
+import com.service.dida.domain.history.usecase.RegisterHistoryUseCase;
 import com.service.dida.domain.market.Market;
 import com.service.dida.domain.market.dto.MarketRequestDto.UpdateMarket;
 import com.service.dida.domain.market.repository.MarketRepository;
@@ -31,6 +32,7 @@ public class UpdateMarketService implements UpdateMarketUseCase {
     private final MarketRepository marketRepository;
     private final WalletUseCase walletUseCase;
     private final RegisterAlarmUseCase registerAlarmUseCase;
+    private final RegisterHistoryUseCase registerHistoryUseCase;
 
     @Override
     public void deleteMarket(Member member, UpdateMarket updateMarket)
@@ -56,5 +58,6 @@ public class UpdateMarketService implements UpdateMarketUseCase {
         }
         walletUseCase.purchaseNftInMarket(buyer, updateMarket.getPayPwd(), market);
         registerAlarmUseCase.registerSaleAlarm(market.getMember(),market.getNft().getNftId());
+        registerHistoryUseCase.registerHistory(market.getNft().getNftId(),buyer);
     }
 }

--- a/src/main/java/com/service/dida/domain/nft/service/RegisterNftService.java
+++ b/src/main/java/com/service/dida/domain/nft/service/RegisterNftService.java
@@ -1,5 +1,6 @@
 package com.service.dida.domain.nft.service;
 
+import com.service.dida.domain.history.usecase.RegisterHistoryUseCase;
 import com.service.dida.domain.member.entity.Member;
 import com.service.dida.domain.nft.Nft;
 import com.service.dida.domain.nft.dto.NftRequestDto.PostNftRequestDto;
@@ -40,6 +41,7 @@ public class RegisterNftService implements RegisterNftUseCase {
     private final KasProperties kasProperties;
     private final RegisterTransactionUseCase registerTransactionUseCase;
     private final WalletUseCase walletUseCase;
+    private final RegisterHistoryUseCase registerHistoryUseCase;
 
     public void save(Nft nft) {
         nftRepository.save(nft);
@@ -80,6 +82,7 @@ public class RegisterNftService implements RegisterNftUseCase {
         registerTransactionUseCase.saveMintingTransaction(
             new MintingTransactionDto(member.getMemberId(), nft,
                 new TransactionSetDto("", transactionHash, sendFee)));
+        registerHistoryUseCase.registerHistory(nft.getNftId(), member);
         return new NftResponseDto.NftId(nft.getNftId());
     }
 }


### PR DESCRIPTION
### 요약

- NFT 소유권 내역 및 키워드 확인 Api 추가
### 상세 내용

- History(소유권 내역) 엔티티 추가 -> 하나의 테이블에 변경되는 소유권 정보를 모두 저장
- 해당 테이블에서 nft관련된 정보를 가져와서 시간순으로 정렬 -> 소유권 내역
- 키워드 테이블 추가 -> 아직 초기버전이라 많은 양의 키워드가 없을 것이라 판단되어 하나의 테이블에 모두 넣음 -> 추후 양이 많아진다면 수정 필요함
### 질문 및 이외 사항

- 
### 이슈 번호

- 