### PR TITLE
SNS 알람 기능 수정

### DIFF
--- a/src/main/java/com/service/dida/domain/comment/service/RegisterCommentService.java
+++ b/src/main/java/com/service/dida/domain/comment/service/RegisterCommentService.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.Objects;
 
 @Service
 @AllArgsConstructor
@@ -41,6 +42,9 @@ public class RegisterCommentService implements RegisterCommentUseCase {
                 .build();
 
         save(comment);
-        registerAlarmUseCase.registerCommentAlarm(post.getMember(), comment.getCommentId());
+
+        if(!Objects.equals(post.getMember().getMemberId(), member.getMemberId())) {
+            registerAlarmUseCase.registerCommentAlarm(post.getMember(), comment.getCommentId());
+        }
     }
 }

--- a/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
+++ b/src/main/java/com/service/dida/domain/like/service/RegisterLikeService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -45,7 +46,9 @@ public class RegisterLikeService implements RegisterLikeUseCase {
         Like like = likeRepository.findByMemberAndNft(member, nft).orElse(null);
         if (like == null) {
             createLike(member, nft);
-            registerAlarmUseCase.registerLikeAlarm(nft.getMember(), nft.getNftId());
+            if(!Objects.equals(nft.getMember().getMemberId(), member.getMemberId())) {
+                registerAlarmUseCase.registerLikeAlarm(nft.getMember(), nft.getNftId());
+            }
             return true;
         } else {
             return like.changeStatus();


### PR DESCRIPTION
### 요약

- 자신의 게시글에 댓글을 달거나 자신의 NFT에 좋아요를 누르면 알람이 생성되는 문제가 발생하여 SNS 알람 기능을 수정했습니다.
### 상세 내용
- 리소스의 주인인 Member와 CurrentMember의 Id를 비교하여 자신의 리소스가 아닌 경우에만 알람 생성되도록 변경
  - 자신의 게시글에 댓글을 달아도 알람이 생성되지 않도록 변경
  - 자신의 NFT에 좋아요를 눌러도 알람이 생성되지 않도록 변경
### 질문 및 이외 사항

- 
### 이슈 번호

- 