### PR TITLE
NFT 소유권 내역 확인 Api 수정

### DIFF
--- a/src/main/java/com/service/dida/domain/history/History.java
+++ b/src/main/java/com/service/dida/domain/history/History.java
@@ -36,6 +36,9 @@ public class History {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(name = "price", nullable = false)
+    private double price;
+
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/src/main/java/com/service/dida/domain/history/controller/GetHistoryController.java
+++ b/src/main/java/com/service/dida/domain/history/controller/GetHistoryController.java
@@ -1,8 +1,10 @@
 package com.service.dida.domain.history.controller;
 
-import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnHistory;
+import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnData;
 import com.service.dida.domain.history.usecase.GetHistoryUseCase;
 import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +23,7 @@ public class GetHistoryController {
      * NFT 소유권 내역 확인하기
      */
     @GetMapping("/history/{nftId}")
-    public ResponseEntity<NftOwnHistory> getNftOwnHistory(@RequestParam("page") int page,
+    public ResponseEntity<PageResponseDto<List<NftOwnData>>> getNftOwnHistory(@RequestParam("page") int page,
         @RequestParam("size") int size, @PathVariable Long nftId) {
         return new ResponseEntity<>(
             getHistoryUseCase.getNftOwnHistory(nftId, new PageRequestDto(page, size)),

--- a/src/main/java/com/service/dida/domain/history/dto/HistoryResponseDto.java
+++ b/src/main/java/com/service/dida/domain/history/dto/HistoryResponseDto.java
@@ -15,12 +15,6 @@ public class HistoryResponseDto {
         private LocalDateTime ownerDate;
         private Long ownerId;
         private String ownerName;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class NftOwnHistory {
-        List<NftOwnData> nftOwnHistory;
+        private double price;
     }
 }

--- a/src/main/java/com/service/dida/domain/history/service/GetHistoryService.java
+++ b/src/main/java/com/service/dida/domain/history/service/GetHistoryService.java
@@ -2,10 +2,10 @@ package com.service.dida.domain.history.service;
 
 import com.service.dida.domain.history.History;
 import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnData;
-import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnHistory;
 import com.service.dida.domain.history.repository.HistoryRepository;
 import com.service.dida.domain.history.usecase.GetHistoryUseCase;
 import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,13 +26,13 @@ public class GetHistoryService implements GetHistoryUseCase {
     }
 
     @Override
-    public NftOwnHistory getNftOwnHistory(Long nftId, PageRequestDto pageRequestDto) {
+    public PageResponseDto<List<NftOwnData>> getNftOwnHistory(Long nftId, PageRequestDto pageRequestDto) {
         List<NftOwnData> nftOwnHistory = new ArrayList<>();
         Page<History> histories = historyRepository.findAllByNftId(nftId, pageReq(pageRequestDto));
         histories.forEach(h -> nftOwnHistory.add(
             new NftOwnData(h.getCreatedAt(), h.getMember().getMemberId(),
-                h.getMember().getNickname())));
+                h.getMember().getNickname(),h.getPrice())));
 
-        return new NftOwnHistory(nftOwnHistory);
+        return new PageResponseDto<>(histories.getNumber(),histories.getSize(),histories.hasNext(),nftOwnHistory);
     }
 }

--- a/src/main/java/com/service/dida/domain/history/service/RegisterHistoryService.java
+++ b/src/main/java/com/service/dida/domain/history/service/RegisterHistoryService.java
@@ -21,11 +21,12 @@ public class RegisterHistoryService implements RegisterHistoryUseCase {
     }
 
     @Override
-    public void registerHistory(Long nftId, Member member) {
+    public void registerHistory(Long nftId, Member member, double price) {
         History history = History.builder()
             .createdAt(LocalDateTime.now())
             .nftId(nftId)
             .member(member)
+            .price(price)
             .build();
         save(history);
     }

--- a/src/main/java/com/service/dida/domain/history/usecase/GetHistoryUseCase.java
+++ b/src/main/java/com/service/dida/domain/history/usecase/GetHistoryUseCase.java
@@ -1,8 +1,10 @@
 package com.service.dida.domain.history.usecase;
 
-import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnHistory;
+import com.service.dida.domain.history.dto.HistoryResponseDto.NftOwnData;
 import com.service.dida.global.common.dto.PageRequestDto;
+import com.service.dida.global.common.dto.PageResponseDto;
+import java.util.List;
 
 public interface GetHistoryUseCase {
-    NftOwnHistory getNftOwnHistory(Long nftId, PageRequestDto pageRequestDto);
+    PageResponseDto<List<NftOwnData>> getNftOwnHistory(Long nftId, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/service/dida/domain/history/usecase/RegisterHistoryUseCase.java
+++ b/src/main/java/com/service/dida/domain/history/usecase/RegisterHistoryUseCase.java
@@ -3,5 +3,5 @@ package com.service.dida.domain.history.usecase;
 import com.service.dida.domain.member.entity.Member;
 
 public interface RegisterHistoryUseCase {
-    void registerHistory(Long nftId, Member member);
+    void registerHistory(Long nftId, Member member, double price);
 }

--- a/src/main/java/com/service/dida/domain/market/service/UpdateMarketService.java
+++ b/src/main/java/com/service/dida/domain/market/service/UpdateMarketService.java
@@ -58,6 +58,6 @@ public class UpdateMarketService implements UpdateMarketUseCase {
         }
         walletUseCase.purchaseNftInMarket(buyer, updateMarket.getPayPwd(), market);
         registerAlarmUseCase.registerSaleAlarm(market.getMember(),market.getNft().getNftId());
-        registerHistoryUseCase.registerHistory(market.getNft().getNftId(),buyer);
+        registerHistoryUseCase.registerHistory(market.getNft().getNftId(),buyer,market.getPrice());
     }
 }

--- a/src/main/java/com/service/dida/domain/nft/service/RegisterNftService.java
+++ b/src/main/java/com/service/dida/domain/nft/service/RegisterNftService.java
@@ -82,7 +82,7 @@ public class RegisterNftService implements RegisterNftUseCase {
         registerTransactionUseCase.saveMintingTransaction(
             new MintingTransactionDto(member.getMemberId(), nft,
                 new TransactionSetDto("", transactionHash, sendFee)));
-        registerHistoryUseCase.registerHistory(nft.getNftId(), member);
+        registerHistoryUseCase.registerHistory(nft.getNftId(), member, 0D);
         return new NftResponseDto.NftId(nft.getNftId());
     }
 }


### PR DESCRIPTION
### 요약

- NFT 소유권 내역 확인 Api 수정
### 상세 내용

- 소유권 정보에 price 추가
- response를 paging response로 변경
### 질문 및 이외 사항

- 
### 이슈 번호

- 