### PR TITLE
Fix: 시끌벅적 게시판 수정

### DIFF
--- a/src/main/java/com/service/dida/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/service/dida/domain/comment/repository/CommentRepository.java
@@ -28,11 +28,11 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "AND c.post.nft.member NOT IN (SELECT mh.hideMember FROM MemberHide mh WHERE mh.member=:member) " +
             "AND c.post.nft NOT IN (SELECT nh.nft FROM NftHide nh WHERE nh.member=:member) " +
             "AND c.post NOT IN (SELECT ph.post FROM PostHide ph WHERE ph.member=:member) " +
-            "AND c.post.createdAt >:date GROUP BY (c.post) ORDER BY COUNT(c.commentId) DESC")
+            "AND c.createdAt >:date GROUP BY (c.post) ORDER BY COUNT(c.commentId) DESC")
     Page<Post> findPostsByCommentCount(Member member, LocalDateTime date, PageRequest pageRequest);
 
     @Query(value = "SELECT c.post FROM Comment c WHERE c.deleted = false " +
-            "AND c.post.createdAt >:date GROUP BY (c.post) ORDER BY COUNT(c.commentId) DESC")
+            "AND c.createdAt >:date GROUP BY (c.post) ORDER BY COUNT(c.commentId) DESC")
     Page<Post> findPostsByCommentCountWithoutHide(LocalDateTime date, PageRequest pageRequest);
 
     Integer countByPostAndDeletedFalse(Post post);


### PR DESCRIPTION
### 요약

- 시끌벅적 게시판 수정
### 상세 내용

- 시끌벅적 게시판의 기준
  - 일주일 내에 가장 댓글이 많이 달린 게시글
- 문제점
  - 일주일 내에 생긴 comment가 아닌 post를 기준으로 댓글을 카운팅 하도록 되어 있어서 comment를 기준으로 변경했습니다.
